### PR TITLE
docs: streamline PR template, review checklist, and wire Phase 1 issue numbers

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,123 +1,34 @@
-<!--
-Thanks for opening a PR. Please fill in the sections below.
+### Related Issues
 
-Reviewer routing is automatic (see `.github/workflows/auto-assign-reviewer.yml`):
-  - Team PR (Priyanka, Aravind, Bhawika)         -> @GunaPalanivel reviews
-  - Outside contributor / fork PR                -> @PriyankaSen0902 reviews
-  - PR opened by @GunaPalanivel                  -> @PriyankaSen0902 reviews
+- closes #
 
-The reviewer walks this PR against `.idea/Plan/PR-Review/Checklist.md`.
+### Proposed Changes
 
-BEFORE pushing: run `pre-commit run --all-files` locally. Do not use `--no-verify`.
--->
+<!-- What does this PR do and why? Be specific about the implementation approach. -->
 
-## Summary
+### How I tested
 
-<!-- 2-3 sentences: what does this PR do, and why? -->
+- Unit:
+  -
+- Integration:
+  -
+- Quality:
+  - `pre-commit run --all-files`
+  - `make test`
+- Regression:
+  - All existing tests pass
 
-## Linked task / issue
+### Notes for reviewers
 
-<!-- Reference TaskSync IDs and/or GitHub issues, e.g. P2-06, #26645 -->
+<!-- Anything the reviewer should pay extra attention to: tricky logic, security implications, architectural decisions, or known limitations. -->
 
-- TaskSync: `P_-_`
-- Closes: #
+### Checklist
 
-## Changes
-
-- <!-- list specific changes; group by file or layer -->
--
--
-
-## How to test
-
-1. <!-- step-by-step verification instructions -->
-2.
-3.
-
-## Screenshots / recordings
-
-<!-- For UI changes, include a before/after screenshot or a short loom/gif. -->
-
-## Author checklist
-
-### Code Quality
-
-- [ ] `pre-commit run --all-files` is clean locally (no `--no-verify`)
-- [ ] Code builds without errors
-- [ ] No unused imports / dead code
-- [ ] Type hints on all Python signatures (`mypy --strict` passes)
-- [ ] No `any` in TypeScript; no `as any` casts
-- [ ] No `console.log` / `print()` in production paths
-- [ ] No hardcoded secrets or URLs
-- [ ] Names are descriptive (`is_active` not `flag`, `classify_columns` not `process`)
-
-### Architecture Integrity (per `CodingStandards.md` Three Laws)
-
-- [ ] Code is in the correct layer (api / services / clients / models)
-- [ ] No business logic in `src/copilot/api/` (greppable: no `if confidence`, no `openai.`, no `client.mcp` imports)
-- [ ] No HTTP types (`HTTPException`, `Request`, `Response`) in `src/copilot/services/`
-- [ ] No business rules in `src/copilot/clients/`
-- [ ] `tests/architecture/test_layer_imports.py` still passes
-
-### Resilience (per `NFRs.md` "The 5 Things AI Never Adds")
-
-- [ ] Every new external HTTP/SDK call has explicit `timeout=`
-- [ ] Every new external call wrapped with `@retry` (`tenacity`)
-- [ ] Every new external call wrapped with a `pybreaker.CircuitBreaker`
-- [ ] Circuit-breaker-open path returns the right structured error envelope
-- [ ] No `requests.*` (use `httpx`); no bare `openai.chat.completions.create()`
-
-### Observability (per `NFRs.md` NFR-06)
-
-- [ ] No `print()` (ruff rule T201)
-- [ ] No bare `logging.*` — only `structlog`
-- [ ] Every service entry/exit has a structlog line
-- [ ] `request_id` propagated end-to-end
-- [ ] New metrics exposed on `GET /api/v1/metrics`
-- [ ] Sensitive data NEVER logged (use redaction processor)
-
-### AI/ML Security — Module G (per `Security/PromptInjectionMitigation.md`)
-
-- [ ] Any new code that fetches catalog content into an LLM prompt calls `services.prompt_safety.neutralize(...)`
-- [ ] Any new tool added to the LLM's available set is added to `ALLOWED_TOOLS` in `services/agent.py`
-- [ ] Any new write tool has `risk_level` set to `soft_write` or `hard_write` and goes through the HITL confirmation gate
-- [ ] LLM JSON output is parsed via `ToolCallProposal.model_validate(...)` before any tool execution
-- [ ] No `pickle`, `joblib`, `yaml.load(unsafe)`, `eval`, `exec`, or `os.system` introduced
-- [ ] `tests/security/test_prompt_injection.py` still covers all 5 canonical patterns
-
-### Tests
-
-- [ ] New code has unit tests (happy path + at least one failure case)
-- [ ] All existing tests still pass (`make test`)
-- [ ] Integration test added if touching MCP client or agent
-- [ ] Test coverage stays above 70% on `src/copilot/`
-
-### Documentation
-
-- [ ] Functions have docstrings
-- [ ] README updated if new setup steps needed
-- [ ] API endpoints documented in `docs/api.md` (if applicable)
-- [ ] Architecture docs updated if design changed (`.idea/Plan/Architecture/*.md`)
-- [ ] CHANGELOG.md entry added under `[Unreleased]`
-
-### Security
-
-- [ ] No secrets in commits (gitleaks clean)
-- [ ] JWT tokens / API keys never logged
-- [ ] Input validation on user-facing endpoints
-- [ ] License header (`LICENSE_HEADER.txt`) added to every new source file
-
-### Phase exit (only if this PR closes the last task in a phase)
-
-- [ ] All gates from `.idea/Plan/Validation/QualityGates.md` for the current phase are green
-
-## Reviewer checklist
-
-- [ ] All sections of the author checklist are honestly filled in
-- [ ] CI is green (lint, types, tests, security scan, secret scan, UI build, path-guard)
-- [ ] No merge conflicts
-- [ ] Branch is rebased on latest `main`
-
----
-
-**Reviewer**: assigned automatically by `.github/workflows/auto-assign-reviewer.yml`
+- [ ] I have read the [coding standards](/.idea/Plan/Architecture/CodingStandards.md) and the [NFRs](/.idea/Plan/Project/NFRs.md)
+- [ ] `pre-commit run --all-files` passes locally
+- [ ] New code has tests (happy path + at least one failure case)
+- [ ] All existing tests still pass
+- [ ] No `print()` or `console.log` in production paths
+- [ ] No secrets, hardcoded URLs, or `--no-verify` commits
+- [ ] Docstrings added for new functions
+- [ ] README updated if new setup steps are needed

--- a/.idea/Plan/PR-Review/Checklist.md
+++ b/.idea/Plan/PR-Review/Checklist.md
@@ -1,86 +1,66 @@
 # PR Review Checklist
 
-## For OMH-GSA (Reviewer) — Use on Every PR
+Walk this checklist on every PR before approving. Skip sections that don't apply (e.g., skip "AI/ML Security" if the PR only touches docs).
 
-### Code Quality
+## Basics
 
+- [ ] `pre-commit run --all-files` is clean (author confirms, no `--no-verify`)
 - [ ] Code builds without errors
 - [ ] No unused imports or dead code
-- [ ] Functions have type hints (Python) / TypeScript types
-- [ ] Variable/function names are descriptive
+- [ ] Type hints on all Python signatures; no `any` / `as any` in TypeScript
+- [ ] Names are descriptive (`classify_columns` not `process`, `is_active` not `flag`)
 - [ ] No hardcoded secrets, tokens, or URLs
-- [ ] Error handling covers expected edge cases
-- [ ] Logging present at INFO level for key operations
-- [ ] Author confirms `pre-commit run --all-files` is clean locally (no `--no-verify` was used)
-
-### Tests
-
-- [ ] New code has unit tests
-- [ ] Tests cover happy path + at least 1 edge case
-- [ ] All existing tests still pass
-- [ ] Integration test added if touching MCP client or agent
-
-### Documentation
-
+- [ ] No `console.log` / `print()` in production paths
 - [ ] Functions have docstrings
-- [ ] README updated if new setup steps needed
-- [ ] API endpoints documented (if applicable)
-- [ ] Architecture docs updated if design changed
 
-### OM Alignment
+## Architecture
 
-- [ ] Uses `data-ai-sdk` for MCP interactions (not raw HTTP)
-- [ ] Auth handled via environment variables (not hardcoded)
-- [ ] MCP tool params match `tools.json` schema exactly
-- [ ] UI follows OM design language (colors, typography)
+Code lives in the right layer. Quick grep to verify:
 
-### Security
-
-- [ ] No secrets in commits (check `.env` not committed)
-- [ ] JWT tokens not logged at INFO level
-- [ ] Input validation on user-facing endpoints
-- [ ] No SQL injection vectors (if applicable)
-
-### Architecture Integrity Review (per Feature-Dev SKILL Phase 7)
-
-- [ ] No business logic in `src/copilot/api/` (greppable: no `if confidence`, no `openai.`, no `client.mcp` imports)
-- [ ] No HTTP types in `src/copilot/services/` (no `HTTPException`, no `Request`, no `Response`)
-- [ ] No business rules in `src/copilot/clients/` (clients only build req → call SDK → map to model → raise typed exception)
-- [ ] No N+1 patterns (batch where possible)
+- [ ] No business logic in `src/copilot/api/` (no `if confidence`, no `openai.`, no `client.mcp`)
+- [ ] No HTTP types in `src/copilot/services/` (no `HTTPException`, `Request`, `Response`)
+- [ ] No business rules in `src/copilot/clients/` (clients: build request, call SDK, map response, raise typed error)
 - [ ] `tests/architecture/test_layer_imports.py` passes
 
-### Resilience Review (per [Project/NFRs.md §The 5 Things AI Never Adds](../Project/NFRs.md))
+## Resilience
 
-- [ ] Every external HTTP/SDK call has explicit `timeout=` (connect + read)
-- [ ] Every external call wrapped with `@retry` (`tenacity`) — exponential + jitter
-- [ ] Every external call wrapped with a `pybreaker.CircuitBreaker`
-- [ ] Circuit-breaker-open path returns the right structured error envelope (`om_unavailable` / `llm_unavailable` / `github_unavailable`)
-- [ ] No `requests.*` (use `httpx`); no bare `openai.chat.completions.create()` (use the wrapped client)
-- [ ] `tests/integration/test_*_resilience.py` covers each circuit's failure + recovery path
+Every external call (MCP, LLM, GitHub) needs three things:
 
-### Observability Review (per [Project/NFRs.md §NFR-06](../Project/NFRs.md))
+- [ ] Explicit `timeout=` (connect + read)
+- [ ] `@retry` with exponential backoff + jitter (`tenacity`)
+- [ ] `pybreaker.CircuitBreaker` wrapping the call
+- [ ] Circuit-breaker-open path returns structured error envelope (`om_unavailable`, `llm_unavailable`, etc.)
+- [ ] No `requests.*` anywhere (use `httpx`); no bare `openai.chat.completions.create()`
+
+## Observability
 
 - [ ] No `print()` (ruff rule T201)
-- [ ] No bare `logging.*` (only `structlog` + the redaction processor)
-- [ ] Every service entry/exit has a structlog line
-- [ ] `request_id` propagated end-to-end (`structlog.contextvars`)
-- [ ] New metrics added are exposed on `GET /api/v1/metrics`
-- [ ] Sensitive data (secrets, prompts, tool args containing user content) NEVER logged
+- [ ] No bare `logging.*` (only `structlog` with redaction processor)
+- [ ] Service entry/exit has a structlog line with `request_id`
+- [ ] Sensitive data (secrets, prompts, user content) never logged
+- [ ] New metrics exposed on `GET /api/v1/metrics` if applicable
 
-### AI/ML Security Review — Module G (per [Security/PromptInjectionMitigation.md](../Security/PromptInjectionMitigation.md))
+## AI/ML Security
 
-- [ ] Any new code that fetches catalog content into an LLM prompt calls `services.prompt_safety.neutralize(field, max_len=...)`
-- [ ] Any new tool added to the LLM's available set is added to the `ALLOWED_TOOLS` set in `services/agent.py`
-- [ ] Any new write tool (creates/mutates entities or external resources) has `risk_level` set to `soft_write` or `hard_write` and goes through the HITL confirmation gate
-- [ ] LLM JSON output is parsed via `ToolCallProposal.model_validate(...)` before any tool execution
-- [ ] No `pickle`, `joblib`, `yaml.load(unsafe)`, `eval`, `exec`, or `os.system` introduced
-- [ ] `tests/security/test_prompt_injection.py` still covers all 5 canonical patterns; new tests added for any new prompt assembly point
+Only applies to PRs that touch LLM prompts, tool registration, or catalog content flowing into prompts.
 
-### Merge Criteria
+- [ ] Catalog content flowing into prompts goes through `services.prompt_safety.neutralize()`
+- [ ] New tools added to `ALLOWED_TOOLS` in `services/agent.py`
+- [ ] Write tools have `risk_level` set (`soft_write` / `hard_write`) and go through HITL confirmation
+- [ ] LLM output parsed via `ToolCallProposal.model_validate()` before execution
+- [ ] No `pickle`, `joblib`, `yaml.load(unsafe)`, `eval`, `exec`, or `os.system`
+- [ ] `tests/security/test_prompt_injection.py` still covers all 5 patterns
 
-- [ ] All checklist sections above satisfied
-- [ ] CI is green (lint, types, tests, pip-audit, bandit, gitleaks per [Security/CIHardening.md](../Security/CIHardening.md))
-- [ ] At least 1 approval from OMH-GSA
-- [ ] No merge conflicts
-- [ ] Branch is rebased on latest `main`
-- [ ] If this PR is the last for a phase: corresponding [Validation/QualityGates.md](../Validation/QualityGates.md) gates all green
+## Tests
+
+- [ ] New code has tests (happy path + at least one failure case)
+- [ ] All existing tests pass (`make test`)
+- [ ] Integration test added if touching MCP client or agent
+- [ ] Coverage stays above 70% on `src/copilot/`
+
+## Merge
+
+- [ ] CI is green (lint, types, tests, security scan, secret scan)
+- [ ] At least 1 approving review
+- [ ] No merge conflicts, branch rebased on `main`
+- [ ] If last PR in a phase: [QualityGates.md](../Validation/QualityGates.md) gates are green

--- a/.idea/Plan/Progress.md
+++ b/.idea/Plan/Progress.md
@@ -14,11 +14,11 @@ Per-person, per-phase progress on every task in [TaskSync.md](./TaskSync.md). On
 
 PRs get a reviewer requested for you by `.github/workflows/auto-assign-reviewer.yml`:
 
-| Author | Reviewer requested |
-| --- | --- |
-| @PriyankaSen0902, @aravindsai003, @5009226-bhawikakumari | @GunaPalanivel |
-| @GunaPalanivel | @PriyankaSen0902 |
-| Outside contributor (forks, community) | @PriyankaSen0902 |
+| Author                                                   | Reviewer requested |
+| -------------------------------------------------------- | ------------------ |
+| @PriyankaSen0902, @aravindsai003, @5009226-bhawikakumari | @GunaPalanivel     |
+| @GunaPalanivel                                           | @PriyankaSen0902   |
+| Outside contributor (forks, community)                   | @PriyankaSen0902   |
 
 Backup: `.github/CODEOWNERS` requests @GunaPalanivel by default if the workflow is disabled.
 
@@ -32,12 +32,12 @@ Each row uses the same 8-step lifecycle. Check the boxes inline:
 
 ## Status legend
 
-| Symbol | Meaning |
-| --- | --- |
-| `[ ]` | Not started |
-| `[/]` | In progress |
-| `[x]` | Done |
-| `[!]` | Blocked (add a note next to the row) |
+| Symbol | Meaning                              |
+| ------ | ------------------------------------ |
+| `[ ]`  | Not started                          |
+| `[/]`  | In progress                          |
+| `[x]`  | Done                                 |
+| `[!]`  | Blocked (add a note next to the row) |
 
 ---
 
@@ -47,27 +47,27 @@ Each row uses the same 8-step lifecycle. Check the boxes inline:
 
 ### @GunaPalanivel
 
-| Task ID | Description | Issue | PR | P | B | V1 | F | V2 | PR opened | R | M |
-| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| P0-01 | Post intent comment on upstream #26645 | upstream | n/a | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] |
-| P0-02 | Post intent comment on upstream #26608 | upstream | n/a | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] |
-| P0-03 | Create repo `GunaPalanivel/openmetadata-mcp-agent` | done | n/a | [x] | [x] | [x] | [x] | [x] | [x] | [x] | [x] |
-| P0-04 | Redeem OpenAI API credits | #__ | n/a | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] |
-| P0-05 | Generate OpenAI API key, save in `.env` | #__ | n/a | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] |
-| P0-06 | Add team as collaborators (3 invites) | #__ | n/a | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] |
-| P0-07 | Drop `CLAUDE.md` template into repo root | #__ | #__ | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] |
-| P0-08 | Star `open-metadata/OpenMetadata` (all 4) | #__ | n/a | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] |
-| P0-09 | Read Discovery + NFRs + CodingStandards + PromptInjection | #__ | n/a | [x] | [x] | [x] | [x] | [x] | [x] | [x] | [x] |
-| P0-10 | Install pre-commit hooks (`pre-commit install` + `run --all-files`) | n/a | n/a | [x] | [x] | [x] | [x] | [x] | [x] | [x] | [x] |
+| Task ID | Description                                                         | Issue                                                                                                | PR    | P   | B   | V1  | F   | V2  | PR opened | R   | M   |
+| ------- | ------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- | ----- | --- | --- | --- | --- | --- | --------- | --- | --- |
+| P0-01   | Post intent comment on upstream #26645                              | [#26645 comment](https://github.com/open-metadata/OpenMetadata/issues/26645#issuecomment-4275961194) | n/a   | [x] | [x] | [x] | [x] | [x] | [x]       | [x] | [x] |
+| P0-02   | Post intent comment on upstream #26608                              | [#26608 comment](https://github.com/open-metadata/OpenMetadata/issues/26608#issuecomment-4275961984) | n/a   | [x] | [x] | [x] | [x] | [x] | [x]       | [x] | [x] |
+| P0-03   | Create repo `GunaPalanivel/openmetadata-mcp-agent`                  | done                                                                                                 | n/a   | [x] | [x] | [x] | [x] | [x] | [x]       | [x] | [x] |
+| P0-04   | Redeem OpenAI API credits (deferred until P2-01)                    | n/a                                                                                                  | n/a   | [!] | [!] | [!] | [!] | [!] | [!]       | [!] | [!] |
+| P0-05   | Generate OpenAI API key, save in `.env` (deferred with P0-04)       | n/a                                                                                                  | n/a   | [!] | [!] | [!] | [!] | [!] | [!]       | [!] | [!] |
+| P0-06   | Add team as collaborators (3 invites)                               | done                                                                                                 | n/a   | [x] | [x] | [x] | [x] | [x] | [x]       | [x] | [x] |
+| P0-07   | Drop `CLAUDE.md` template into repo root                            | done                                                                                                 | done  | [x] | [x] | [x] | [x] | [x] | [x]       | [x] | [x] |
+| P0-08   | Star `open-metadata/OpenMetadata` (all 4)                           | done                                                                                                 | n/a   | [x] | [x] | [x] | [x] | [x] | [x]       | [x] | [x] |
+| P0-09   | Read Discovery + NFRs + CodingStandards + PromptInjection           | #\_\_                                                                                                | n/a   | [x] | [x] | [x] | [x] | [x] | [x]       | [x] | [x] |
+| P0-10   | Install pre-commit hooks (`pre-commit install` + `run --all-files`) | n/a                                                                                                  | n/a   | [x] | [x] | [x] | [x] | [x] | [x]       | [x] | [x] |
 
 ### Per-person setup (every contributor)
 
-| Owner | P0-10 Install pre-commit hooks |
-| --- | --- |
-| @GunaPalanivel | [x] |
-| @PriyankaSen0902 | [ ] |
-| @aravindsai003 | [ ] |
-| @5009226-bhawikakumari | [ ] |
+| Owner                  | P0-10 Install pre-commit hooks |
+| ---------------------- | ------------------------------ |
+| @GunaPalanivel         | [x]                            |
+| @PriyankaSen0902       | [ ]                            |
+| @aravindsai003         | [ ]                            |
+| @5009226-bhawikakumari | [ ]                            |
 
 ---
 
@@ -89,43 +89,43 @@ Each row uses the same 8-step lifecycle. Check the boxes inline:
 
 ### @GunaPalanivel
 
-| Task ID | Description | Issue | PR | P | B | V1 | F | V2 | PR opened | R | M |
-| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| P1-01 | Init repo with `pyproject.toml` and Phase 1 deps | #__ | #__ | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] |
-| P1-02 | Create project structure (`src/copilot/...`, `ui/`, `tests/`) | #__ | #__ | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] |
-| P1-03 | Implement MCP client `search_metadata` happy path | #__ | #__ | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] |
-| P1-04 | LangGraph agent skeleton (NL → intent → tool → respond) | #__ | #__ | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] |
-| P1-05 | Verify smoke: search returns data | #__ | #__ | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] |
-| P1-06 | Review all Phase 1 PRs | #__ | n/a | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] |
+| Task ID | Description                                                   | Issue                                                                       | PR  | P   | B   | V1  | F   | V2  | PR opened | R   | M   |
+| ------- | ------------------------------------------------------------- | --------------------------------------------------------------------------- | --- | --- | --- | --- | --- | --- | --------- | --- | --- |
+| P1-01   | Init repo with `pyproject.toml` and Phase 1 deps              | [#14](https://github.com/GunaPalanivel/openmetadata-mcp-agent/issues/14)    |     | [ ] | [ ] | [ ] | [ ] | [ ] | [ ]       | [ ] | [ ] |
+| P1-02   | Create project structure (`src/copilot/...`, `ui/`, `tests/`) | [#15](https://github.com/GunaPalanivel/openmetadata-mcp-agent/issues/15)    |     | [ ] | [ ] | [ ] | [ ] | [ ] | [ ]       | [ ] | [ ] |
+| P1-03   | Implement MCP client `search_metadata` happy path             | [#16](https://github.com/GunaPalanivel/openmetadata-mcp-agent/issues/16)    |     | [ ] | [ ] | [ ] | [ ] | [ ] | [ ]       | [ ] | [ ] |
+| P1-04   | LangGraph agent skeleton (NL -> intent -> tool -> respond)    | [#17](https://github.com/GunaPalanivel/openmetadata-mcp-agent/issues/17)    |     | [ ] | [ ] | [ ] | [ ] | [ ] | [ ]       | [ ] | [ ] |
+| P1-05   | Verify smoke: search returns data                             | [#18](https://github.com/GunaPalanivel/openmetadata-mcp-agent/issues/18)    |     | [ ] | [ ] | [ ] | [ ] | [ ] | [ ]       | [ ] | [ ] |
+| P1-06   | Review all Phase 1 PRs                                        | [#19](https://github.com/GunaPalanivel/openmetadata-mcp-agent/issues/19)    | n/a | [ ] | [ ] | [ ] | [ ] | [ ] | [ ]       | [ ] | [ ] |
 
 ### @PriyankaSen0902
 
-| Task ID | Description | Issue | PR | P | B | V1 | F | V2 | PR opened | R | M |
-| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| P1-07 | Study `data-ai-sdk` + `langchain-openai`, document tool schemas | #__ | #__ | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] |
-| P1-08 | Map all 12 MCP tools to governance use cases (update audit doc) | #__ | #__ | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] |
-| P1-09 | Typed wrapper for top 6 tools (Pydantic params + responses) | #__ | #__ | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] |
-| P1-10 | 10+ unit tests for MCP client wrapper (mock responses) | #__ | #__ | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] |
+| Task ID | Description                                                     | Issue                                                                       | PR  | P   | B   | V1  | F   | V2  | PR opened | R   | M   |
+| ------- | --------------------------------------------------------------- | --------------------------------------------------------------------------- | --- | --- | --- | --- | --- | --- | --------- | --- | --- |
+| P1-07   | Study `data-ai-sdk` + `langchain-openai`, document tool schemas | [#20](https://github.com/GunaPalanivel/openmetadata-mcp-agent/issues/20)    |     | [ ] | [ ] | [ ] | [ ] | [ ] | [ ]       | [ ] | [ ] |
+| P1-08   | Map all 12 MCP tools to governance use cases (update audit doc) | [#21](https://github.com/GunaPalanivel/openmetadata-mcp-agent/issues/21)    |     | [ ] | [ ] | [ ] | [ ] | [ ] | [ ]       | [ ] | [ ] |
+| P1-09   | Typed wrapper for top 6 tools (Pydantic params + responses)     | [#22](https://github.com/GunaPalanivel/openmetadata-mcp-agent/issues/22)    |     | [ ] | [ ] | [ ] | [ ] | [ ] | [ ]       | [ ] | [ ] |
+| P1-10   | 10+ unit tests for MCP client wrapper (mock responses)          | [#23](https://github.com/GunaPalanivel/openmetadata-mcp-agent/issues/23)    |     | [ ] | [ ] | [ ] | [ ] | [ ] | [ ]       | [ ] | [ ] |
 
 ### @aravindsai003
 
-| Task ID | Description | Issue | PR | P | B | V1 | F | V2 | PR opened | R | M |
-| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| P1-11 | Local OM at `:8585` via `docker/development/` | #__ | #__ | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] |
-| P1-12 | Verify Swagger; generate Bot JWT | #__ | #__ | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] |
-| P1-13 | Pre-seed OM with 50+ realistic tables | #__ | #__ | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] |
-| P1-14 | Scaffold React chat UI (Vite + React) | #__ | #__ | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] |
-| P1-15 | Document setup in `README.md` (clone to run in 5 min) | #__ | #__ | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] |
+| Task ID | Description                                           | Issue                                                                       | PR  | P   | B   | V1  | F   | V2  | PR opened | R   | M   |
+| ------- | ----------------------------------------------------- | --------------------------------------------------------------------------- | --- | --- | --- | --- | --- | --- | --------- | --- | --- |
+| P1-11   | Local OM at `:8585` via `docker/development/`         | [#24](https://github.com/GunaPalanivel/openmetadata-mcp-agent/issues/24)    |     | [ ] | [ ] | [ ] | [ ] | [ ] | [ ]       | [ ] | [ ] |
+| P1-12   | Generate Bot JWT, share privately                     | [#25](https://github.com/GunaPalanivel/openmetadata-mcp-agent/issues/25)    |     | [ ] | [ ] | [ ] | [ ] | [ ] | [ ]       | [ ] | [ ] |
+| P1-13   | Pre-seed OM with 50+ realistic tables                 | [#26](https://github.com/GunaPalanivel/openmetadata-mcp-agent/issues/26)    |     | [ ] | [ ] | [ ] | [ ] | [ ] | [ ]       | [ ] | [ ] |
+| P1-14   | Confirm UI scaffold runs on `:3000`                   | [#27](https://github.com/GunaPalanivel/openmetadata-mcp-agent/issues/27)    |     | [ ] | [ ] | [ ] | [ ] | [ ] | [ ]       | [ ] | [ ] |
+| P1-15   | Document setup in `README.md` (clone to run in 5 min) | [#28](https://github.com/GunaPalanivel/openmetadata-mcp-agent/issues/28)    |     | [ ] | [ ] | [ ] | [ ] | [ ] | [ ]       | [ ] | [ ] |
 
 ### @5009226-bhawikakumari
 
-| Task ID | Description | Issue | PR | P | B | V1 | F | V2 | PR opened | R | M |
-| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| P1-16 | Write project `README.md` (1-liner, features, setup) | #__ | #__ | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] |
-| P1-17 | Daily monitor unassigned hackathon GFIs | #__ | n/a | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] |
-| P1-18 | Add AI disclosure to `README.md` | #__ | #__ | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] |
-| P1-19 | Draft demo narrative outline (refresh `Demo/Narrative.md`) | #__ | #__ | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] |
-| P1-20 | Daily refresh `Demo/CompetitiveMatrix.md` | #__ | n/a | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] |
+| Task ID | Description                                                | Issue                                                                       | PR  | P   | B   | V1  | F   | V2  | PR opened | R   | M   |
+| ------- | ---------------------------------------------------------- | --------------------------------------------------------------------------- | --- | --- | --- | --- | --- | --- | --------- | --- | --- |
+| P1-16   | Polish public README (1-liner, features, setup)            | [#29](https://github.com/GunaPalanivel/openmetadata-mcp-agent/issues/29)    |     | [ ] | [ ] | [ ] | [ ] | [ ] | [ ]       | [ ] | [ ] |
+| P1-17   | Daily monitor unassigned hackathon GFIs                    | [#30](https://github.com/GunaPalanivel/openmetadata-mcp-agent/issues/30)    | n/a | [ ] | [ ] | [ ] | [ ] | [ ] | [ ]       | [ ] | [ ] |
+| P1-18   | Add AI disclosure to `README.md`                           | [#31](https://github.com/GunaPalanivel/openmetadata-mcp-agent/issues/31)    |     | [ ] | [ ] | [ ] | [ ] | [ ] | [ ]       | [ ] | [ ] |
+| P1-19   | Draft demo narrative outline (refresh `Demo/Narrative.md`) | [#32](https://github.com/GunaPalanivel/openmetadata-mcp-agent/issues/32)    |     | [ ] | [ ] | [ ] | [ ] | [ ] | [ ]       | [ ] | [ ] |
+| P1-20   | Daily refresh `Demo/CompetitiveMatrix.md`                  | [#33](https://github.com/GunaPalanivel/openmetadata-mcp-agent/issues/33)    | n/a | [ ] | [ ] | [ ] | [ ] | [ ] | [ ]       | [ ] | [ ] |
 
 ### Phase 1 Exit Gate
 
@@ -157,44 +157,44 @@ Each row uses the same 8-step lifecycle. Check the boxes inline:
 
 ### @GunaPalanivel
 
-| Task ID | Description | Issue | PR | P | B | V1 | F | V2 | PR opened | R | M |
-| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| P2-01 | Auto-classification: scan + LLM classify + HITL + `patch_entity` | #__ | #__ | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] |
-| P2-02 | Lineage impact analysis report with Tier warnings | #__ | #__ | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] |
-| P2-03 | Multi-step agent: chain 3+ tool calls per turn | #__ | #__ | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] |
-| P2-04 | FastAPI `POST /chat` wired to LangGraph agent | #__ | #__ | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] |
-| P2-05 | Review all Phase 2 PRs (full PR-Review checklist) | #__ | n/a | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] |
+| Task ID | Description                                                      | Issue | PR    | P   | B   | V1  | F   | V2  | PR opened | R   | M   |
+| ------- | ---------------------------------------------------------------- | ----- | ----- | --- | --- | --- | --- | --- | --------- | --- | --- |
+| P2-01   | Auto-classification: scan + LLM classify + HITL + `patch_entity` | #\_\_ | #\_\_ | [ ] | [ ] | [ ] | [ ] | [ ] | [ ]       | [ ] | [ ] |
+| P2-02   | Lineage impact analysis report with Tier warnings                | #\_\_ | #\_\_ | [ ] | [ ] | [ ] | [ ] | [ ] | [ ]       | [ ] | [ ] |
+| P2-03   | Multi-step agent: chain 3+ tool calls per turn                   | #\_\_ | #\_\_ | [ ] | [ ] | [ ] | [ ] | [ ] | [ ]       | [ ] | [ ] |
+| P2-04   | FastAPI `POST /chat` wired to LangGraph agent                    | #\_\_ | #\_\_ | [ ] | [ ] | [ ] | [ ] | [ ] | [ ]       | [ ] | [ ] |
+| P2-05   | Review all Phase 2 PRs (full PR-Review checklist)                | #\_\_ | n/a   | [ ] | [ ] | [ ] | [ ] | [ ] | [ ]       | [ ] | [ ] |
 
 ### @PriyankaSen0902
 
-| Task ID | Description | Issue | PR | P | B | V1 | F | V2 | PR opened | R | M |
-| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| P2-06 | NL query engine: text → intent → tool → Markdown | #__ | #__ | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] |
-| P2-07 | Governance summary: tag coverage %, PII %, unclassified count | #__ | #__ | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] |
-| P2-08 | Retry + circuit breaker + structured error envelope on MCP calls | #__ | #__ | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] |
-| P2-09 | Integration tests including circuit-breaker-open paths | #__ | #__ | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] |
-| P2-10b | `services/prompt_safety.neutralize` + 5-pattern test file | #__ | #__ | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] |
-| P2-11b | `observability/redact.py` + `middleware/error_envelope.py` | #__ | #__ | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] |
+| Task ID | Description                                                      | Issue | PR    | P   | B   | V1  | F   | V2  | PR opened | R   | M   |
+| ------- | ---------------------------------------------------------------- | ----- | ----- | --- | --- | --- | --- | --- | --------- | --- | --- |
+| P2-06   | NL query engine: text → intent → tool → Markdown                 | #\_\_ | #\_\_ | [ ] | [ ] | [ ] | [ ] | [ ] | [ ]       | [ ] | [ ] |
+| P2-07   | Governance summary: tag coverage %, PII %, unclassified count    | #\_\_ | #\_\_ | [ ] | [ ] | [ ] | [ ] | [ ] | [ ]       | [ ] | [ ] |
+| P2-08   | Retry + circuit breaker + structured error envelope on MCP calls | #\_\_ | #\_\_ | [ ] | [ ] | [ ] | [ ] | [ ] | [ ]       | [ ] | [ ] |
+| P2-09   | Integration tests including circuit-breaker-open paths           | #\_\_ | #\_\_ | [ ] | [ ] | [ ] | [ ] | [ ] | [ ]       | [ ] | [ ] |
+| P2-10b  | `services/prompt_safety.neutralize` + 5-pattern test file        | #\_\_ | #\_\_ | [ ] | [ ] | [ ] | [ ] | [ ] | [ ]       | [ ] | [ ] |
+| P2-11b  | `observability/redact.py` + `middleware/error_envelope.py`       | #\_\_ | #\_\_ | [ ] | [ ] | [ ] | [ ] | [ ] | [ ]       | [ ] | [ ] |
 
 ### @aravindsai003
 
-| Task ID | Description | Issue | PR | P | B | V1 | F | V2 | PR opened | R | M |
-| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| P2-10 | Connect React UI to FastAPI (real chat responses) | #__ | #__ | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] |
-| P2-11 | Render structured responses (markdown + sanitize, no innerHTML) | #__ | #__ | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] |
-| P2-12 | HITL confirmation modal (tool name, risk, FQN list, Confirm/Cancel) | #__ | #__ | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] |
-| P2-13 | E2E test including the prompt-injection demo flow | #__ | #__ | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] |
-| P2-13b | Build + commit `seed/customer_db.json` and `scripts/load_seed.py` | #__ | #__ | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] |
+| Task ID | Description                                                         | Issue | PR    | P   | B   | V1  | F   | V2  | PR opened | R   | M   |
+| ------- | ------------------------------------------------------------------- | ----- | ----- | --- | --- | --- | --- | --- | --------- | --- | --- |
+| P2-10   | Connect React UI to FastAPI (real chat responses)                   | #\_\_ | #\_\_ | [ ] | [ ] | [ ] | [ ] | [ ] | [ ]       | [ ] | [ ] |
+| P2-11   | Render structured responses (markdown + sanitize, no innerHTML)     | #\_\_ | #\_\_ | [ ] | [ ] | [ ] | [ ] | [ ] | [ ]       | [ ] | [ ] |
+| P2-12   | HITL confirmation modal (tool name, risk, FQN list, Confirm/Cancel) | #\_\_ | #\_\_ | [ ] | [ ] | [ ] | [ ] | [ ] | [ ]       | [ ] | [ ] |
+| P2-13   | E2E test including the prompt-injection demo flow                   | #\_\_ | #\_\_ | [ ] | [ ] | [ ] | [ ] | [ ] | [ ]       | [ ] | [ ] |
+| P2-13b  | Build + commit `seed/customer_db.json` and `scripts/load_seed.py`   | #\_\_ | #\_\_ | [ ] | [ ] | [ ] | [ ] | [ ] | [ ]       | [ ] | [ ] |
 
 ### @5009226-bhawikakumari
 
-| Task ID | Description | Issue | PR | P | B | V1 | F | V2 | PR opened | R | M |
-| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| P2-14 | Claim + fix a GFI issue if an unassigned one appears | upstream | upstream | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] |
-| P2-15 | README Mermaid architecture + trust-boundary diagram | #__ | #__ | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] |
-| P2-16 | Refresh `Demo/Narrative.md` with measurable outcomes | #__ | #__ | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] |
-| P2-17 | Document all 12 MCP tools used in README (cite audit) | #__ | #__ | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] |
-| P2-18 | Daily refresh `Demo/CompetitiveMatrix.md` | #__ | n/a | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] |
+| Task ID | Description                                           | Issue    | PR       | P   | B   | V1  | F   | V2  | PR opened | R   | M   |
+| ------- | ----------------------------------------------------- | -------- | -------- | --- | --- | --- | --- | --- | --------- | --- | --- |
+| P2-14   | Claim + fix a GFI issue if an unassigned one appears  | upstream | upstream | [ ] | [ ] | [ ] | [ ] | [ ] | [ ]       | [ ] | [ ] |
+| P2-15   | README Mermaid architecture + trust-boundary diagram  | #\_\_    | #\_\_    | [ ] | [ ] | [ ] | [ ] | [ ] | [ ]       | [ ] | [ ] |
+| P2-16   | Refresh `Demo/Narrative.md` with measurable outcomes  | #\_\_    | #\_\_    | [ ] | [ ] | [ ] | [ ] | [ ] | [ ]       | [ ] | [ ] |
+| P2-17   | Document all 12 MCP tools used in README (cite audit) | #\_\_    | #\_\_    | [ ] | [ ] | [ ] | [ ] | [ ] | [ ]       | [ ] | [ ] |
+| P2-18   | Daily refresh `Demo/CompetitiveMatrix.md`             | #\_\_    | n/a      | [ ] | [ ] | [ ] | [ ] | [ ] | [ ]       | [ ] | [ ] |
 
 ### Phase 2 Exit Gate
 
@@ -226,43 +226,43 @@ Each row uses the same 8-step lifecycle. Check the boxes inline:
 
 ### @GunaPalanivel
 
-| Task ID | Description | Issue | PR | P | B | V1 | F | V2 | PR opened | R | M |
-| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| P3-01 | Multi-MCP: connect GitHub MCP via `langchain-mcp-adapters` | #__ | #__ | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] |
-| P3-02 | Cross-MCP: find PII tables → open GitHub issue per table | #__ | #__ | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] |
-| P3-03 | Governance summary aggregation (coverage + tier distribution) | #__ | #__ | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] |
-| P3-04 | Security audit (no secrets, no debug logs, input validation) | #__ | #__ | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] |
-| P3-05 | Review all Phase 3 PRs | #__ | n/a | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] |
+| Task ID | Description                                                   | Issue | PR    | P   | B   | V1  | F   | V2  | PR opened | R   | M   |
+| ------- | ------------------------------------------------------------- | ----- | ----- | --- | --- | --- | --- | --- | --------- | --- | --- |
+| P3-01   | Multi-MCP: connect GitHub MCP via `langchain-mcp-adapters`    | #\_\_ | #\_\_ | [ ] | [ ] | [ ] | [ ] | [ ] | [ ]       | [ ] | [ ] |
+| P3-02   | Cross-MCP: find PII tables → open GitHub issue per table      | #\_\_ | #\_\_ | [ ] | [ ] | [ ] | [ ] | [ ] | [ ]       | [ ] | [ ] |
+| P3-03   | Governance summary aggregation (coverage + tier distribution) | #\_\_ | #\_\_ | [ ] | [ ] | [ ] | [ ] | [ ] | [ ]       | [ ] | [ ] |
+| P3-04   | Security audit (no secrets, no debug logs, input validation)  | #\_\_ | #\_\_ | [ ] | [ ] | [ ] | [ ] | [ ] | [ ]       | [ ] | [ ] |
+| P3-05   | Review all Phase 3 PRs                                        | #\_\_ | n/a   | [ ] | [ ] | [ ] | [ ] | [ ] | [ ]       | [ ] | [ ] |
 
 ### @PriyankaSen0902
 
-| Task ID | Description | Issue | PR | P | B | V1 | F | V2 | PR opened | R | M |
-| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| P3-06 | Edge cases as structured error envelope | #__ | #__ | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] |
-| P3-07 | structlog + redact processor + request_id propagation; no `print()` | #__ | #__ | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] |
-| P3-08 | Coverage report >70% on `src/copilot/` | #__ | #__ | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] |
-| P3-09 | Full hardened GitHub Actions CI per `Security/CIHardening.md` | #__ | #__ | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] |
-| P3-09b | `/metrics` endpoint exposing the 4 Golden Signals | #__ | #__ | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] |
+| Task ID | Description                                                         | Issue | PR    | P   | B   | V1  | F   | V2  | PR opened | R   | M   |
+| ------- | ------------------------------------------------------------------- | ----- | ----- | --- | --- | --- | --- | --- | --------- | --- | --- |
+| P3-06   | Edge cases as structured error envelope                             | #\_\_ | #\_\_ | [ ] | [ ] | [ ] | [ ] | [ ] | [ ]       | [ ] | [ ] |
+| P3-07   | structlog + redact processor + request_id propagation; no `print()` | #\_\_ | #\_\_ | [ ] | [ ] | [ ] | [ ] | [ ] | [ ]       | [ ] | [ ] |
+| P3-08   | Coverage report >70% on `src/copilot/`                              | #\_\_ | #\_\_ | [ ] | [ ] | [ ] | [ ] | [ ] | [ ]       | [ ] | [ ] |
+| P3-09   | Full hardened GitHub Actions CI per `Security/CIHardening.md`       | #\_\_ | #\_\_ | [ ] | [ ] | [ ] | [ ] | [ ] | [ ]       | [ ] | [ ] |
+| P3-09b  | `/metrics` endpoint exposing the 4 Golden Signals                   | #\_\_ | #\_\_ | [ ] | [ ] | [ ] | [ ] | [ ] | [ ]       | [ ] | [ ] |
 
 ### @aravindsai003
 
-| Task ID | Description | Issue | PR | P | B | V1 | F | V2 | PR opened | R | M |
-| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| P3-10 | OM-native UI (`#7147E8`, Inter font, dark mode default) | #__ | #__ | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] |
-| P3-11 | Governance dashboard (tag coverage chart, PII summary cards) | #__ | #__ | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] |
-| P3-12 | Responsive layout for judging on different screens | #__ | #__ | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] |
-| P3-13 | Loading + error states polished | #__ | #__ | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] |
+| Task ID | Description                                                  | Issue | PR    | P   | B   | V1  | F   | V2  | PR opened | R   | M   |
+| ------- | ------------------------------------------------------------ | ----- | ----- | --- | --- | --- | --- | --- | --------- | --- | --- |
+| P3-10   | OM-native UI (`#7147E8`, Inter font, dark mode default)      | #\_\_ | #\_\_ | [ ] | [ ] | [ ] | [ ] | [ ] | [ ]       | [ ] | [ ] |
+| P3-11   | Governance dashboard (tag coverage chart, PII summary cards) | #\_\_ | #\_\_ | [ ] | [ ] | [ ] | [ ] | [ ] | [ ]       | [ ] | [ ] |
+| P3-12   | Responsive layout for judging on different screens           | #\_\_ | #\_\_ | [ ] | [ ] | [ ] | [ ] | [ ] | [ ]       | [ ] | [ ] |
+| P3-13   | Loading + error states polished                              | #\_\_ | #\_\_ | [ ] | [ ] | [ ] | [ ] | [ ] | [ ]       | [ ] | [ ] |
 
 ### @5009226-bhawikakumari
 
-| Task ID | Description | Issue | PR | P | B | V1 | F | V2 | PR opened | R | M |
-| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| P3-14 | Run the 3-rehearsal protocol | #__ | n/a | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] |
-| P3-15 | Record `demo/final_recording.mp4` (2 to 3 min, 1920x1080) | #__ | #__ | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] |
-| P3-16 | Record + verify `demo/backup_recording.mp4` | #__ | #__ | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] |
-| P3-17 | Finalize README (GIF top, 3-cmd setup, AI disclosure, links) | #__ | #__ | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] |
-| P3-18 | Verify clone-to-run on a clean machine | #__ | n/a | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] |
-| P3-19 | Architecture + trust-boundary Mermaid embedded in README | #__ | #__ | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] |
+| Task ID | Description                                                  | Issue | PR    | P   | B   | V1  | F   | V2  | PR opened | R   | M   |
+| ------- | ------------------------------------------------------------ | ----- | ----- | --- | --- | --- | --- | --- | --------- | --- | --- |
+| P3-14   | Run the 3-rehearsal protocol                                 | #\_\_ | n/a   | [ ] | [ ] | [ ] | [ ] | [ ] | [ ]       | [ ] | [ ] |
+| P3-15   | Record `demo/final_recording.mp4` (2 to 3 min, 1920x1080)    | #\_\_ | #\_\_ | [ ] | [ ] | [ ] | [ ] | [ ] | [ ]       | [ ] | [ ] |
+| P3-16   | Record + verify `demo/backup_recording.mp4`                  | #\_\_ | #\_\_ | [ ] | [ ] | [ ] | [ ] | [ ] | [ ]       | [ ] | [ ] |
+| P3-17   | Finalize README (GIF top, 3-cmd setup, AI disclosure, links) | #\_\_ | #\_\_ | [ ] | [ ] | [ ] | [ ] | [ ] | [ ]       | [ ] | [ ] |
+| P3-18   | Verify clone-to-run on a clean machine                       | #\_\_ | n/a   | [ ] | [ ] | [ ] | [ ] | [ ] | [ ]       | [ ] | [ ] |
+| P3-19   | Architecture + trust-boundary Mermaid embedded in README     | #\_\_ | #\_\_ | [ ] | [ ] | [ ] | [ ] | [ ] | [ ]       | [ ] | [ ] |
 
 ### Phase 3 Exit Gate
 
@@ -292,29 +292,29 @@ Each row uses the same 8-step lifecycle. Check the boxes inline:
 
 ### All team
 
-| Task ID | Owner | Description | Issue | PR | P | B | V1 | F | V2 | PR opened | R | M |
-| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| P4-00 | @GunaPalanivel | Run `Validation/PRR.md` PRR checklist end-to-end | #__ | #__ | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] |
-| P4-01 | @5009226-bhawikakumari | Final README review | #__ | n/a | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] |
-| P4-02 | @GunaPalanivel | Repo hygiene + `gitleaks detect` returns 0 findings | #__ | n/a | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] |
-| P4-03 | @5009226-bhawikakumari | AI disclosure confirmed in README | #__ | n/a | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] |
-| P4-03b | @GunaPalanivel | `SECURITY_AUDIT_2026-04-25.md` with SC-N status | #__ | #__ | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] |
-| P4-03c | @aravindsai003 | Demo machine pre-conditions checklist | #__ | n/a | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] |
-| P4-04 | @GunaPalanivel | Submit hackathon form on WeMakeDevs | #__ | n/a | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] |
-| P4-05 | @GunaPalanivel | Link demo video + repo in submission | #__ | n/a | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] |
-| P4-06 | @5009226-bhawikakumari | Verify GFI PR status | #__ | n/a | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] |
-| P4-07 | @GunaPalanivel | Comment submission link on #26645 + #26608 | upstream | n/a | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] |
-| P4-08 | All | Team retrospective within 48h | #__ | n/a | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] |
+| Task ID | Owner                  | Description                                         | Issue    | PR    | P   | B   | V1  | F   | V2  | PR opened | R   | M   |
+| ------- | ---------------------- | --------------------------------------------------- | -------- | ----- | --- | --- | --- | --- | --- | --------- | --- | --- |
+| P4-00   | @GunaPalanivel         | Run `Validation/PRR.md` PRR checklist end-to-end    | #\_\_    | #\_\_ | [ ] | [ ] | [ ] | [ ] | [ ] | [ ]       | [ ] | [ ] |
+| P4-01   | @5009226-bhawikakumari | Final README review                                 | #\_\_    | n/a   | [ ] | [ ] | [ ] | [ ] | [ ] | [ ]       | [ ] | [ ] |
+| P4-02   | @GunaPalanivel         | Repo hygiene + `gitleaks detect` returns 0 findings | #\_\_    | n/a   | [ ] | [ ] | [ ] | [ ] | [ ] | [ ]       | [ ] | [ ] |
+| P4-03   | @5009226-bhawikakumari | AI disclosure confirmed in README                   | #\_\_    | n/a   | [ ] | [ ] | [ ] | [ ] | [ ] | [ ]       | [ ] | [ ] |
+| P4-03b  | @GunaPalanivel         | `SECURITY_AUDIT_2026-04-25.md` with SC-N status     | #\_\_    | #\_\_ | [ ] | [ ] | [ ] | [ ] | [ ] | [ ]       | [ ] | [ ] |
+| P4-03c  | @aravindsai003         | Demo machine pre-conditions checklist               | #\_\_    | n/a   | [ ] | [ ] | [ ] | [ ] | [ ] | [ ]       | [ ] | [ ] |
+| P4-04   | @GunaPalanivel         | Submit hackathon form on WeMakeDevs                 | #\_\_    | n/a   | [ ] | [ ] | [ ] | [ ] | [ ] | [ ]       | [ ] | [ ] |
+| P4-05   | @GunaPalanivel         | Link demo video + repo in submission                | #\_\_    | n/a   | [ ] | [ ] | [ ] | [ ] | [ ] | [ ]       | [ ] | [ ] |
+| P4-06   | @5009226-bhawikakumari | Verify GFI PR status                                | #\_\_    | n/a   | [ ] | [ ] | [ ] | [ ] | [ ] | [ ]       | [ ] | [ ] |
+| P4-07   | @GunaPalanivel         | Comment submission link on #26645 + #26608          | upstream | n/a   | [ ] | [ ] | [ ] | [ ] | [ ] | [ ]       | [ ] | [ ] |
+| P4-08   | All                    | Team retrospective within 48h                       | #\_\_    | n/a   | [ ] | [ ] | [ ] | [ ] | [ ] | [ ]       | [ ] | [ ] |
 
 ---
 
 ## Snapshot per person (counts so far)
 
-| Owner | Phase 0 | Phase 1 | Phase 2 | Phase 3 | Phase 4 | Total |
-| --- | --- | --- | --- | --- | --- | --- |
-| @GunaPalanivel | 9 | 6 | 5 | 5 | 6 | 31 |
-| @PriyankaSen0902 | 0 | 4 | 6 | 5 | 0 | 15 |
-| @aravindsai003 | 0 | 5 | 5 | 4 | 1 | 15 |
-| @5009226-bhawikakumari | 0 | 5 | 5 | 6 | 3 | 19 |
+| Owner                  | Phase 0 | Phase 1 | Phase 2 | Phase 3 | Phase 4 | Total |
+| ---------------------- | ------- | ------- | ------- | ------- | ------- | ----- |
+| @GunaPalanivel         | 9       | 6       | 5       | 5       | 6       | 31    |
+| @PriyankaSen0902       | 0       | 4       | 6       | 5       | 0       | 15    |
+| @aravindsai003         | 0       | 5       | 5       | 4       | 1       | 15    |
+| @5009226-bhawikakumari | 0       | 5       | 5       | 6       | 3       | 19    |
 
 Update the counts above only if you add or remove rows.


### PR DESCRIPTION
### Related Issues
None (housekeeping)

### Proposed Changes

- Rewrite PR template to be lightweight (35 lines, 8 checks for authors)
- Rewrite review checklist to be scannable with skip-if-not-applicable guidance
- Wire actual GitHub issue numbers (#14-#33) into Progress.md Phase 1 tables
- All 20 Phase 1 issue bodies already updated on GitHub (cleaner descriptions, no redundant Owner line, linked dependencies)

### How I tested

Manual review of all 20 issues on GitHub. Spot-checked #16, #23, #24, #29.

### Checklist

- [x] Templates follow OSS standards
- [x] No secrets or hardcoded URLs