### PR TITLE
docs(P1-01): verify Phase 1 runtime deps and track progress (#14)

### DIFF
--- a/.idea/Plan/FeatureDev/Phase1Dependencies.md
+++ b/.idea/Plan/FeatureDev/Phase1Dependencies.md
@@ -1,0 +1,84 @@
+# Phase 1 Dependencies — `pyproject.toml` (P1-01 / #14)
+
+## Owner: OMH-GSA (Guna)
+
+## Phase: 1 (Foundation, Day 3–4)
+
+## Tracks: [P1-01](https://github.com/GunaPalanivel/openmetadata-mcp-agent/issues/14) → unblocks [#16](https://github.com/GunaPalanivel/openmetadata-mcp-agent/issues/16) (MCP client)
+
+---
+
+## Overview
+
+Five runtime dependencies are required for the agent to function end-to-end: one official
+OpenMetadata Python SDK, one LLM orchestration library, one LLM binding, one ASGI
+framework, and one ASGI server. This spec pins each, cross-references the rationale in
+[Project/TechStackDR.md](../Project/TechStackDR.md), and records how the install +
+`make ci-local` gates were validated before unblocking #16.
+
+## The Five Phase 1 Deps
+
+| # | Package | Pin (in `pyproject.toml`) | Resolved at verify | Role | Rationale (TechStackDR §) |
+|---|---------|----------------------------|--------------------|------|----------------------------|
+| 1 | `data-ai-sdk[langchain]` | `==0.1.2` | `0.1.2` | Official OM Python SDK — typed `MCPTool` enum, `client.mcp.as_langchain_tools()`, `AI_SDK_HOST` / `AI_SDK_TOKEN` wiring | [MCP Client](../Project/TechStackDR.md) |
+| 2 | `langgraph` | `>=0.2.0,<0.3.0` | `0.2.76` | State-machine orchestration: `intent → tool select → execute → validate → confirm → respond` | [Agent Orchestration](../Project/TechStackDR.md) |
+| 3 | `langchain-openai` | `>=0.2.0,<0.3.0` | `0.2.14` | LangChain binding for OpenAI GPT-4o-mini; paired with `langgraph` tool-calling | [LLM Provider](../Project/TechStackDR.md) |
+| 4 | `fastapi` | `>=0.110.0,<0.120.0` | `0.119.1` | ASGI framework for `/api/v1/chat`, `/api/v1/healthz`, `/api/v1/metrics`; free OpenAPI docs | [Backend](../Project/TechStackDR.md) |
+| 5 | `uvicorn[standard]` | `>=0.27.0,<0.40.0` | `0.39.0` | Async server for FastAPI; `[standard]` pulls `uvloop` + `httptools` for perf | [Backend](../Project/TechStackDR.md) |
+
+> `langchain-mcp-adapters` is intentionally **not** in Phase 1. `data-ai-sdk[langchain]` already
+> exposes `client.mcp.as_langchain_tools()` for OM, so the adapter is only needed in Phase 3
+> when wiring the GitHub MCP server — per [TaskSync.md](../TaskSync.md) note at P1-01.
+
+## Verification Commands
+
+```bash
+python3.11 -m venv .venv
+source .venv/bin/activate
+pip install --upgrade pip
+pip install -e ".[dev]"
+
+python -c "
+import importlib, importlib.metadata as md
+for mod, dist in [('fastapi','fastapi'),('uvicorn','uvicorn'),
+                  ('langgraph','langgraph'),('langchain_openai','langchain-openai'),
+                  ('ai_sdk','data-ai-sdk')]:
+    importlib.import_module(mod)
+    print(f'{mod:20s} {md.version(dist)}')
+"
+
+make ci-local
+```
+
+## Done when
+
+- [x] All five deps listed in [`pyproject.toml`](../../../pyproject.toml) lines 40–53
+- [x] `pip install -e ".[dev]"` exits 0 on Python 3.11.15 (log attached in PR)
+- [x] Five deps import cleanly and resolve to the versions in the table above
+- [ ] `make ci-local` is green end-to-end — see "Known pre-existing failures" below; the
+      pre-commit and license-header gates fail for reasons unrelated to the five Phase-1
+      deps. Fixes are tracked as separate follow-up issues per the P1-01 scope rule.
+
+## Known pre-existing failures (out of scope for P1-01)
+
+These are reported, not fixed, in this task. They will be addressed in follow-up issues so
+P1-01 can close cleanly and #16 can proceed.
+
+1. **`tests/conftest.py` has CRLF line endings.** `ruff` auto-rewrites them to LF when the
+   `pre-commit-all` hook runs, which fails the `files were modified by this hook` gate.
+   Root cause: file was checked in with Windows line endings. Fix: one-line re-save with
+   LF + commit. Does not involve the five Phase-1 deps.
+2. **`scripts/check_license_headers.py` scans `.git/`.** The `SKIP_PATH_PARTS` set (line 22
+   of that script) omits `.git`, so local user scripts that happen to live inside the
+   `.git/` metadata directory get flagged as missing an Apache 2.0 header. Fix: add `.git`
+   to `SKIP_PATH_PARTS`. Again unrelated to Phase-1 deps.
+
+Both failures reproduce on `main` (branch `phase-1/p1-01-pin-deps` has zero commits over
+`main` at the time of P1-01 validation), which confirms they are pre-existing.
+
+## Exit criteria
+
+- PR closes #14
+- Progress.md row for P1-01 is marked through `PR opened` (the reviewer ticks `R` and `M`)
+- Follow-up issues are open for the two `make ci-local` gate failures above so #16 is
+  truly unblocked and not just deferred

--- a/.idea/Plan/Progress.md
+++ b/.idea/Plan/Progress.md
@@ -91,7 +91,7 @@ Each row uses the same 8-step lifecycle. Check the boxes inline:
 
 | Task ID | Description                                                   | Issue                                                                       | PR  | P   | B   | V1  | F   | V2  | PR opened | R   | M   |
 | ------- | ------------------------------------------------------------- | --------------------------------------------------------------------------- | --- | --- | --- | --- | --- | --- | --------- | --- | --- |
-| P1-01   | Init repo with `pyproject.toml` and Phase 1 deps              | [#14](https://github.com/GunaPalanivel/openmetadata-mcp-agent/issues/14)    |     | [ ] | [ ] | [ ] | [ ] | [ ] | [ ]       | [ ] | [ ] |
+| P1-01   | Init repo with `pyproject.toml` and Phase 1 deps              | [#14](https://github.com/GunaPalanivel/openmetadata-mcp-agent/issues/14)    |     | [x] | [x] | [x] | [x] | [x] | [x]       | [ ] | [ ] |
 | P1-02   | Create project structure (`src/copilot/...`, `ui/`, `tests/`) | [#15](https://github.com/GunaPalanivel/openmetadata-mcp-agent/issues/15)    |     | [ ] | [ ] | [ ] | [ ] | [ ] | [ ]       | [ ] | [ ] |
 | P1-03   | Implement MCP client `search_metadata` happy path             | [#16](https://github.com/GunaPalanivel/openmetadata-mcp-agent/issues/16)    |     | [ ] | [ ] | [ ] | [ ] | [ ] | [ ]       | [ ] | [ ] |
 | P1-04   | LangGraph agent skeleton (NL -> intent -> tool -> respond)    | [#17](https://github.com/GunaPalanivel/openmetadata-mcp-agent/issues/17)    |     | [ ] | [ ] | [ ] | [ ] | [ ] | [ ]       | [ ] | [ ] |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ## [Unreleased]
 
+### Verified
+
+- **P1-01 / [#14](https://github.com/GunaPalanivel/openmetadata-mcp-agent/issues/14)** — Phase 1 runtime dependencies install clean on Python 3.11.15: `data-ai-sdk[langchain]==0.1.2`, `langgraph==0.2.76`, `langchain-openai==0.2.14`, `fastapi==0.119.1`, `uvicorn[standard]==0.39.0`. All five imports resolve via `pip install -e ".[dev]"`. Feature-Dev spec: [`.idea/Plan/FeatureDev/Phase1Dependencies.md`](.idea/Plan/FeatureDev/Phase1Dependencies.md). Unblocks [#16](https://github.com/GunaPalanivel/openmetadata-mcp-agent/issues/16).
+
 ## [0.1.0] - 2026-04-19
 
 ### Added


### PR DESCRIPTION
## Summary

- Closes #14 (P1-01). 

All five Phase 1 runtime dependencies were already present in [`pyproject.toml`](pyproject.toml) at lines 40–53, so this PR records the install + `make ci-local` verification needed to close the issue's "Done when" gates. **No `pyproject.toml` changes.**

## Dep verification (Python 3.11.15, fresh `.venv`)

| # | Package | Pin in `pyproject.toml` | Resolved version |
|---|---|---|---|
| 1 | `data-ai-sdk[langchain]` | `==0.1.2` | `0.1.2` |
| 2 | `langgraph` | `>=0.2.0,<0.3.0` | `0.2.76` |
| 3 | `langchain-openai` | `>=0.2.0,<0.3.0` | `0.2.14` |
| 4 | `fastapi` | `>=0.110.0,<0.120.0` | `0.119.1` |
| 5 | `uvicorn[standard]` | `>=0.27.0,<0.40.0` | `0.39.0` |

### `pip install -e ".[dev]"` — exit 0

```
$ python3.11 -m venv .venv && source .venv/bin/activate
$ pip install -e ".[dev]"
...
Successfully built openmetadata-mcp-agent
Successfully installed ... data-ai-sdk-0.1.2 ... fastapi-0.119.1 ... langchain-openai-0.2.14 ... langgraph-0.2.76 ... uvicorn-0.39.0 ...
```

### Import smoke-check — all five resolve

```
$ python -c "import importlib, importlib.metadata as md; ..."
fastapi              0.119.1
uvicorn              0.39.0
langgraph            0.2.76
langchain_openai     0.2.14
ai_sdk               0.1.2
ALL FIVE PHASE-1 DEPS RESOLVE CLEANLY
```

## Changes

- **New** `.idea/Plan/FeatureDev/Phase1Dependencies.md` — feature spec with the dep table, TechStackDR cross-refs, verification commands, and the two out-of-scope CI-local follow-ups below.
- **Update** `.idea/Plan/Progress.md` — tick `P / B / V1 / F / V2 / PR opened` on the P1-01 row.
- **Update** `CHANGELOG.md` — `[Unreleased]` entry recording the Phase-1 dep verification.

No edits to `pyproject.toml`, `Makefile`, `src/`, `tests/`, `ui/`, or CI workflows.

## Known pre-existing `make ci-local` failures (out of scope for P1-01)

Per the P1-01 scope rule ("will follow up phase by phase"), these are reported but not fixed here. Both reproduce on `main`:

1. **`tests/conftest.py` has CRLF line endings.** `ruff` auto-rewrites them to LF when `pre-commit-all` runs, which triggers the `files were modified by this hook` gate.
   - Root cause: file checked in with Windows line endings.
   - Fix: re-save as LF and commit.

2. **`scripts/check_license_headers.py` scans `.git/`.** The `SKIP_PATH_PARTS` set (line 22 of that script) omits `.git`, so local user scratch scripts that happen to live inside the `.git/` metadata directory get flagged as missing an Apache 2.0 header. Example files flagged:
   - `.git/open_p1_issues.py`, `.git/update_p1_issues_v2.py`, `.git/update_p1_issues.py`, `.git/rewrite_head.py`
   - Root cause: `SKIP_PATH_PARTS` missing `.git`.
   - Fix: add `".git"` to the `SKIP_PATH_PARTS` set.

Both are unrelated to the five Phase-1 deps and will be filed as separate follow-up issues.

## Test plan

- [x] `pip install -e ".[dev]"` exits 0 on Python 3.11.15 in a fresh `.venv`.
- [x] All five deps import cleanly at the resolved versions above.
- [x] `pre-commit run --files CHANGELOG.md .idea/Plan/Progress.md .idea/Plan/FeatureDev/Phase1Dependencies.md` is green (no ruff/mypy/test churn — doc-only).
- [x] `tests/conftest.py` was **not** modified by this PR (the ruff auto-fix from `make ci-local` was reverted to keep scope clean).
- [ ] `make ci-local` end-to-end green — blocked by the two pre-existing failures above; follow-ups filed separately.
- [ ] CI green on this PR (push-triggered `lint`, `typecheck`, `test-unit`, `security-scan`, `secret-scan`, `ui-build`, `path-guard`).



- Unblocks #16 (MCP client).