### PR TITLE
add local openmetadata docker compose setup with startup script and make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,9 @@
 # =============================================================================
 
 .DEFAULT_GOAL := help
-.PHONY: help install install_dev_env install_ui install-hooks demo demo-cached demo-fresh \
+.PHONY: help install install_dev_env install_ui install-hooks \
+        om-start om-stop om-health om-logs \
+        demo demo-cached demo-fresh \
         restart-agent test test-unit test-integration test-security test-arch \
         lint py_format static-checks license-header-check pre-commit-all ci-local clean
 
@@ -22,6 +24,12 @@ help:
 	@echo "    make install_dev_env      Alias for 'make install' (matches OM upstream Makefile)"
 	@echo "    make install_ui           Install UI dependencies only"
 	@echo "    make install-hooks        Install + run pre-commit hooks (required before first commit)"
+	@echo ""
+	@echo "  OpenMetadata (local OM at :8585):"
+	@echo "    make om-start            Start OpenMetadata + MySQL + Elasticsearch"
+	@echo "    make om-stop             Stop and remove OpenMetadata containers"
+	@echo "    make om-health           Check if OpenMetadata health endpoint is responding"
+	@echo "    make om-logs             Tail OpenMetadata server logs"
 	@echo ""
 	@echo "  Run:"
 	@echo "    make demo                 Start agent backend + UI for live demo"
@@ -63,6 +71,23 @@ install-hooks:
 	pre-commit install
 	pre-commit run --all-files
 	@echo "Pre-commit hooks installed and clean."
+
+# -----------------------------------------------------------------------------
+# OpenMetadata local instance
+# -----------------------------------------------------------------------------
+om-start:
+	@bash scripts/start_om.sh
+
+om-stop:
+	@echo "Stopping OpenMetadata stack ..."
+	docker compose -f infrastructure/docker-compose.om.yml down
+	@echo "OpenMetadata stopped."
+
+om-health:
+	@curl -sf http://localhost:8585/api/v1/health && echo " ← OM healthy" || echo "OM not reachable at :8585"
+
+om-logs:
+	docker compose -f infrastructure/docker-compose.om.yml logs -f openmetadata-server
 
 # -----------------------------------------------------------------------------
 # Run

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -20,19 +20,23 @@ cd openmetadata-mcp-agent
 
 ## Step 2: Bring up OpenMetadata
 
-You need a running OpenMetadata instance for the agent to call. The simplest path is the upstream Docker compose:
+You need a running OpenMetadata instance for the agent to call. This repo ships a self-contained Docker Compose stack:
 
 ```bash
-# Get OpenMetadata (sibling directory recommended)
-git clone https://github.com/open-metadata/OpenMetadata.git ../OpenMetadata
-docker compose -f ../OpenMetadata/docker/development/docker-compose.yml up -d
+# One command — starts MySQL, Elasticsearch, and OpenMetadata server
+make om-start
+# Waits for health automatically; prints next steps when ready.
 
-# Wait ~60 seconds, then verify:
+# Verify manually (optional):
 curl http://localhost:8585/api/v1/health
 # Expected: {"status":"healthy"}
 ```
 
-If you already have OpenMetadata running somewhere else, set `AI_SDK_HOST` in your `.env` to point to it.
+This uses `infrastructure/docker-compose.om.yml` (OM v1.6.2, MySQL 8, Elasticsearch 7.16). Total memory: ~6 GB. Make sure Docker Desktop has at least 8 GB allocated (Settings → Resources).
+
+To stop: `make om-stop`. To check health: `make om-health`. To tail logs: `make om-logs`.
+
+If you already have OpenMetadata running somewhere else, skip this step and set `AI_SDK_HOST` in your `.env` to point to it.
 
 ## Step 3: Generate a Bot JWT
 

--- a/infrastructure/docker-compose.om.yml
+++ b/infrastructure/docker-compose.om.yml
@@ -1,0 +1,112 @@
+# =============================================================================
+# docker-compose.om.yml — Local OpenMetadata instance for development
+#
+# Brings up OpenMetadata server + MySQL + Elasticsearch on the host network.
+# The agent backend connects to OM at http://localhost:8585 via AI_SDK_HOST.
+#
+# Usage:
+#   docker compose -f infrastructure/docker-compose.om.yml up -d
+#   curl http://localhost:8585/api/v1/health
+#
+# Memory: total stack stays under 8 GB with the limits below.
+# See also: docs/getting-started.md, .idea/Plan/Validation/SetupGuide.md
+# =============================================================================
+
+services:
+  openmetadata-mysql:
+    image: mysql:8
+    container_name: openmetadata-mysql
+    restart: unless-stopped
+    environment:
+      MYSQL_ROOT_PASSWORD: password
+      MYSQL_USER: openmetadata_user
+      MYSQL_PASSWORD: openmetadata_password
+      MYSQL_DATABASE: openmetadata_db
+    ports:
+      - "3306:3306"
+    volumes:
+      - om-mysql-data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "root", "-ppassword"]
+      interval: 15s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
+    deploy:
+      resources:
+        limits:
+          memory: 1G
+
+  openmetadata-elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.16.3
+    container_name: openmetadata-elasticsearch
+    restart: unless-stopped
+    environment:
+      discovery.type: single-node
+      ES_JAVA_OPTS: "-Xms512m -Xmx512m"
+      xpack.security.enabled: "false"
+    ports:
+      - "9200:9200"
+      - "9300:9300"
+    volumes:
+      - om-es-data:/usr/share/elasticsearch/data
+    healthcheck:
+      test: ["CMD-SHELL", "curl -s http://localhost:9200/_cluster/health | grep -qE '\"status\":\"(green|yellow)\"'"]
+      interval: 15s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
+    deploy:
+      resources:
+        limits:
+          memory: 1G
+
+  openmetadata-server:
+    image: docker.getcollate.io/openmetadata/server:1.6.2
+    container_name: openmetadata-server
+    restart: unless-stopped
+    depends_on:
+      openmetadata-mysql:
+        condition: service_healthy
+      openmetadata-elasticsearch:
+        condition: service_healthy
+    environment:
+      OPENMETADATA_CLUSTER_NAME: openmetadata
+      SERVER_HOST_API_URL: http://localhost:8585/api
+      SERVER_ADMIN_PORT: "8586"
+      SERVER_PORT: "8585"
+      # MySQL connection
+      DB_DRIVER_CLASS: com.mysql.cj.jdbc.Driver
+      DB_SCHEME: mysql
+      DB_HOST: openmetadata-mysql
+      DB_PORT: "3306"
+      DB_USER: openmetadata_user
+      DB_USER_PASSWORD: openmetadata_password
+      DB_NAME: openmetadata_db
+      # Elasticsearch connection
+      SEARCH_TYPE: elasticsearch
+      ELASTICSEARCH_HOST: openmetadata-elasticsearch
+      ELASTICSEARCH_PORT: "9200"
+      ELASTICSEARCH_SCHEME: http
+      # Airflow disabled (not needed for agent development)
+      PIPELINE_SERVICE_CLIENT_ENABLED: "false"
+      PIPELINE_SERVICE_CLIENT_CLASS_NAME: "org.openmetadata.service.clients.pipeline.noop.NoopClient"
+    ports:
+      - "8585:8585"
+      - "8586:8586"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -s http://localhost:8585/api/v1/health | grep -q healthy || exit 1"]
+      interval: 15s
+      timeout: 10s
+      retries: 20
+      start_period: 60s
+    deploy:
+      resources:
+        limits:
+          memory: 4G
+
+volumes:
+  om-mysql-data:
+    driver: local
+  om-es-data:
+    driver: local

--- a/scripts/start_om.sh
+++ b/scripts/start_om.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# =============================================================================
+# start_om.sh — Start the local OpenMetadata container stack and wait for
+# the health endpoint to report healthy.
+#
+# Copyright 2026 Collate Inc.
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# =============================================================================
+
+set -euo pipefail
+
+COMPOSE_FILE="infrastructure/docker-compose.om.yml"
+HEALTH_URL="http://localhost:8585/api/v1/health"
+MAX_RETRIES=40
+RETRY_INTERVAL=5
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+info()  { echo -e "${GREEN}[INFO]${NC}  $*"; }
+warn()  { echo -e "${YELLOW}[WARN]${NC}  $*"; }
+error() { echo -e "${RED}[ERROR]${NC} $*" >&2; }
+
+check_prerequisites() {
+    if ! command -v docker &>/dev/null; then
+        error "Docker is not installed or not in PATH."
+        error "Install from https://docs.docker.com/get-docker/"
+        exit 1
+    fi
+
+    if ! docker compose version &>/dev/null; then
+        error "Docker Compose V2 is not available."
+        error "Update Docker or install the compose plugin."
+        exit 1
+    fi
+
+    if ! docker info &>/dev/null 2>&1; then
+        error "Docker daemon is not running. Start Docker Desktop or the daemon."
+        exit 1
+    fi
+}
+
+start_stack() {
+    info "Starting OpenMetadata stack from ${COMPOSE_FILE} ..."
+    docker compose -f "${COMPOSE_FILE}" up -d
+    info "Containers started. Waiting for OpenMetadata to become healthy ..."
+}
+
+wait_for_health() {
+    local attempt=1
+    while [ "${attempt}" -le "${MAX_RETRIES}" ]; do
+        if curl -sf "${HEALTH_URL}" 2>/dev/null | grep -q "healthy"; then
+            echo ""
+            info "OpenMetadata is healthy at ${HEALTH_URL}"
+            return 0
+        fi
+        printf "\r  Waiting... attempt %d/%d (next check in %ds)" \
+            "${attempt}" "${MAX_RETRIES}" "${RETRY_INTERVAL}"
+        sleep "${RETRY_INTERVAL}"
+        attempt=$((attempt + 1))
+    done
+
+    echo ""
+    error "OpenMetadata did not become healthy after $((MAX_RETRIES * RETRY_INTERVAL))s."
+    error "Check logs: docker compose -f ${COMPOSE_FILE} logs openmetadata-server"
+    exit 1
+}
+
+print_next_steps() {
+    echo ""
+    info "============================================"
+    info "  OpenMetadata is running at :8585"
+    info "============================================"
+    echo ""
+    echo "  UI:      http://localhost:8585"
+    echo "  Login:   admin / admin"
+    echo "  Health:  curl ${HEALTH_URL}"
+    echo ""
+    echo "  Next steps:"
+    echo "    1. Generate a Bot JWT (Settings → Bots → ingestion-bot)"
+    echo "    2. Paste into .env as AI_SDK_TOKEN=<token>"
+    echo "    3. Run: make demo"
+    echo ""
+    echo "  Stop OM:  make om-stop"
+    echo "  Logs:     make om-logs"
+    echo ""
+}
+
+main() {
+    info "OpenMetadata local setup — openmetadata-mcp-agent"
+    echo ""
+    check_prerequisites
+    start_stack
+    wait_for_health
+    print_next_steps
+}
+
+main "$@"


### PR DESCRIPTION
### Related Issues

- Closes #24

---

### Proposed Changes

Adds a self-contained local OpenMetadata setup.
`make om-start` brings up a working OM instance at `http://localhost:8585` without cloning upstream.

#### New files

* `infrastructure/docker-compose.om.yml`
  OpenMetadata (v1.6.2) + MySQL 8 + Elasticsearch 7.16.3
  Includes healthchecks and memory limits (~6 GB total)

* `scripts/start_om.sh`
  Startup script with:

  * Docker prerequisite checks
  * Health endpoint polling (timeout ~200s)

#### Modified files

* `Makefile`
  Added:

  * `om-start`
  * `om-stop`
  * `om-health`
  * `om-logs`

* `docs/getting-started.md`
  Replaced manual setup with `make om-start`

---

### Design Decisions

| Area       | Choice                  | Reason                                   |
| ---------- | ----------------------- | ---------------------------------------- |
| OM Version | 1.6.2                   | Reproducible, matches hackathon baseline |
| DB         | MySQL 8                 | Upstream default                         |
| Search     | Elasticsearch 7.16.3    | Compatible with OM 1.6.x                 |
| Airflow    | Disabled (`NoopClient`) | Not needed for MCP dev                   |
| Compose    | Separate file           | Matches existing infra separation        |

---

### How I Tested

| Component  | Command                                                         | Result           |
| ---------- | --------------------------------------------------------------- | ---------------- |
| Compose    | `docker compose -f infrastructure/docker-compose.om.yml config` | Valid            |
| Script     | `bash -n scripts/start_om.sh`                                   | No syntax errors |
| Makefile   | `make help`                                                     | Targets visible  |
| Quality    | `pre-commit run --all-files`                                    | Pass             |
| Regression | Existing tests                                                  | Pass             |

---

### Notes for Reviewers

* OM runs independently from agent backend
  Connection via: `AI_SDK_HOST=http://localhost:8585`

* Local-only creds:
  `MySQL root password = password`

* Memory usage:

  * MySQL: 1 GB
  * ES: 1 GB
  * OM: 4 GB
    Total: ~6 GB → Docker needs ≥8 GB

* `start_om.sh` includes Apache 2.0 header (per CodePatterns.md §5)

---

### Checklist

* [x] Coding standards + NFRs reviewed
* [x] `pre-commit` passes
* [x] No impact to existing tests
* [x] No debug logs in prod paths
* [x] No secrets / unsafe flags
* [x] Docs updated (`getting-started.md`)