### PR TITLE
feat(models): add typed Pydantic wrappers for top 6 MCP tools (P1-09)

### DIFF
--- a/src/copilot/clients/om_mcp.py
+++ b/src/copilot/clients/om_mcp.py
@@ -45,10 +45,35 @@ from tenacity import (
 
 from copilot.config import get_settings
 from copilot.middleware.error_envelope import McpAuthFailed, McpUnavailable
+from copilot.models.mcp_tools import (
+    CreateGlossaryParams,
+    CreateGlossaryResponse,
+    CreateGlossaryTermParams,
+    CreateGlossaryTermResponse,
+    GetEntityDetailsParams,
+    GetEntityDetailsResponse,
+    GetEntityLineageParams,
+    GetEntityLineageResponse,
+    PatchEntityParams,
+    PatchEntityResponse,
+    SearchMetadataParams,
+    SearchMetadataResponse,
+)
 from copilot.observability import get_logger
 from copilot.observability.metrics import agent_mcp_calls_total
 
-__all__ = ["MCPError", "call_tool", "list_tools", "search_metadata"]
+__all__ = [
+    "MCPError",
+    "call_tool",
+    "create_glossary_term_typed",
+    "create_glossary_typed",
+    "get_entity_details_typed",
+    "get_entity_lineage_typed",
+    "list_tools",
+    "patch_entity_typed",
+    "search_metadata",
+    "search_metadata_typed",
+]
 
 log = get_logger(__name__)
 
@@ -265,3 +290,144 @@ def search_metadata(
         arguments["limit"] = limit
 
     return call_tool("search_metadata", arguments)
+
+
+# ---------------------------------------------------------------------------
+# Typed wrappers (P1-09: issue #22)
+# ---------------------------------------------------------------------------
+
+
+def search_metadata_typed(params: SearchMetadataParams) -> SearchMetadataResponse:
+    """Search metadata with typed input validation and response parsing.
+
+    Args:
+        params: Validated search parameters.
+
+    Returns:
+        Parsed ``SearchMetadataResponse`` with typed hits.
+
+    Raises:
+        McpUnavailable: On connection / timeout errors.
+        McpAuthFailed: On authentication errors.
+    """
+    raw = call_tool(
+        "search_metadata",
+        params.model_dump(by_alias=True, exclude_none=True),
+    )
+
+    # The OM server returns search hits under various shapes.  Normalise to
+    # the ``hits`` / ``total`` structure our response model expects.
+    hits_raw = raw.get("hits", raw.get("data", []))
+    if isinstance(hits_raw, dict):
+        hits_raw = hits_raw.get("hits", [])
+    total = raw.get("total", raw.get("totalCount", len(hits_raw)))
+
+    return SearchMetadataResponse.model_validate(
+        {"hits": hits_raw, "total": total, **raw},
+    )
+
+
+def get_entity_details_typed(
+    params: GetEntityDetailsParams,
+) -> GetEntityDetailsResponse:
+    """Get entity details with typed input validation and response parsing.
+
+    Args:
+        params: Validated entity lookup parameters.
+
+    Returns:
+        Parsed ``GetEntityDetailsResponse`` with entity fields.
+
+    Raises:
+        McpUnavailable: On connection / timeout errors.
+        McpAuthFailed: On authentication errors.
+    """
+    raw = call_tool(
+        "get_entity_details",
+        params.model_dump(by_alias=True, exclude_none=True),
+    )
+    return GetEntityDetailsResponse.model_validate(raw)
+
+
+def get_entity_lineage_typed(
+    params: GetEntityLineageParams,
+) -> GetEntityLineageResponse:
+    """Get entity lineage with typed input validation and response parsing.
+
+    Args:
+        params: Validated lineage query parameters.
+
+    Returns:
+        Parsed ``GetEntityLineageResponse`` with nodes and edges.
+
+    Raises:
+        McpUnavailable: On connection / timeout errors.
+        McpAuthFailed: On authentication errors.
+    """
+    raw = call_tool(
+        "get_entity_lineage",
+        params.model_dump(by_alias=True, exclude_none=True),
+    )
+    return GetEntityLineageResponse.model_validate(raw)
+
+
+def create_glossary_typed(params: CreateGlossaryParams) -> CreateGlossaryResponse:
+    """Create a glossary with typed input validation and response parsing.
+
+    Args:
+        params: Validated glossary creation parameters.
+
+    Returns:
+        Parsed ``CreateGlossaryResponse`` with the created entity.
+
+    Raises:
+        McpUnavailable: On connection / timeout errors.
+        McpAuthFailed: On authentication errors.
+    """
+    raw = call_tool(
+        "create_glossary",
+        params.model_dump(by_alias=True, exclude_none=True),
+    )
+    return CreateGlossaryResponse.model_validate(raw)
+
+
+def create_glossary_term_typed(
+    params: CreateGlossaryTermParams,
+) -> CreateGlossaryTermResponse:
+    """Create a glossary term with typed input validation and response parsing.
+
+    Args:
+        params: Validated glossary term creation parameters.
+
+    Returns:
+        Parsed ``CreateGlossaryTermResponse`` with the created entity.
+
+    Raises:
+        McpUnavailable: On connection / timeout errors.
+        McpAuthFailed: On authentication errors.
+    """
+    raw = call_tool(
+        "create_glossary_term",
+        params.model_dump(by_alias=True, exclude_none=True),
+    )
+    return CreateGlossaryTermResponse.model_validate(raw)
+
+
+def patch_entity_typed(params: PatchEntityParams) -> PatchEntityResponse:
+    """Patch an entity with typed input validation and response parsing.
+
+    Args:
+        params: Validated entity patch parameters.
+
+    Returns:
+        Parsed ``PatchEntityResponse`` with the updated entity.
+
+    Raises:
+        McpUnavailable: On connection / timeout errors.
+        McpAuthFailed: On authentication errors.
+    """
+    raw = call_tool(
+        "patch_entity",
+        params.model_dump(by_alias=True, exclude_none=True),
+    )
+    return PatchEntityResponse.model_validate(raw)

--- a/src/copilot/models/__init__.py
+++ b/src/copilot/models/__init__.py
@@ -26,16 +26,46 @@ from copilot.models.chat import (
     ToolCallRecord,
     ToolName,
 )
+from copilot.models.mcp_tools import (
+    CreateGlossaryParams,
+    CreateGlossaryResponse,
+    CreateGlossaryTermParams,
+    CreateGlossaryTermResponse,
+    GetEntityDetailsParams,
+    GetEntityDetailsResponse,
+    GetEntityLineageParams,
+    GetEntityLineageResponse,
+    PatchEntityParams,
+    PatchEntityResponse,
+    SearchMetadataParams,
+    SearchMetadataResponse,
+)
 
 __all__ = [
+    # chat.py
     "ChatSession",
     "ClassificationJob",
+    # mcp_tools.py — Params
+    "CreateGlossaryParams",
+    # mcp_tools.py — Responses
+    "CreateGlossaryResponse",
+    "CreateGlossaryTermParams",
+    "CreateGlossaryTermResponse",
     "ErrorEnvelope",
+    "GetEntityDetailsParams",
+    "GetEntityDetailsResponse",
+    "GetEntityLineageParams",
+    "GetEntityLineageResponse",
     "LineageImpactReport",
     "LineageNode",
+    "PatchEntityParams",
+    "PatchEntityResponse",
     "RiskLevel",
+    "SearchMetadataParams",
+    "SearchMetadataResponse",
     "TagSuggestion",
     "ToolCallProposal",
     "ToolCallRecord",
     "ToolName",
 ]
+

--- a/src/copilot/models/mcp_tools.py
+++ b/src/copilot/models/mcp_tools.py
@@ -1,0 +1,399 @@
+#  Copyright 2026 Collate Inc.
+#  Licensed under the Apache License, Version 2.0 (the "License"); you may
+#  not use this file except in compliance with the License. You may obtain
+#  a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Typed Pydantic v2 wrappers for the top 6 MCP tools.
+
+Per issue #22 (P1-09): raw ``call_tool`` returns untyped dicts.  These models
+validate inputs **before** the SDK call and parse responses **after**, catching
+bugs at the boundary instead of deep inside business logic.
+
+Schemas sourced from:
+  - ``.idea/Plan/DataFindings/ExistingMCPAudit.md`` (canonical reference)
+  - ``openmetadata-mcp/src/main/resources/json/data/mcp/tools.json``
+
+Design rules:
+  - Params: strict validation (``extra="forbid"``), snake_case fields with
+    camelCase ``alias`` for SDK serialization.
+  - Response: permissive (``extra="allow"``) because OM server may add fields.
+  - All models use ``populate_by_name=True`` so callers can use snake_case.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+# =============================================================================
+# Shared base classes
+# =============================================================================
+
+
+class _StrictParams(BaseModel):
+    """Base for all Params models — strict, aliased, no extras."""
+
+    model_config = ConfigDict(
+        populate_by_name=True,
+        extra="forbid",
+        frozen=True,
+    )
+
+
+class _PermissiveResponse(BaseModel):
+    """Base for all Response models — permissive to tolerate OM server changes."""
+
+    model_config = ConfigDict(
+        populate_by_name=True,
+        extra="allow",
+    )
+
+
+# =============================================================================
+# Tool 1: search_metadata
+# =============================================================================
+
+
+class SearchMetadataParams(_StrictParams):
+    """Input parameters for the ``search_metadata`` MCP tool.
+
+    All parameters are optional — calling with no args returns the first page
+    of all entities.
+    """
+
+    query: str | None = Field(
+        default=None,
+        description="Natural language or keyword search query.",
+    )
+    entity_type: str | None = Field(
+        default=None,
+        alias="entityType",
+        description="Filter by entity type (singular): table, dashboard, topic, etc.",
+    )
+    query_filter: str | None = Field(
+        default=None,
+        alias="queryFilter",
+        description="Advanced OpenSearch JSON query string. Overrides ``query``.",
+    )
+    from_: int = Field(
+        default=0,
+        ge=0,
+        alias="from",
+        description="Pagination offset.",
+    )
+    size: int = Field(
+        default=10,
+        ge=1,
+        le=50,
+        description="Results per page (max 50).",
+    )
+    include_deleted: bool = Field(
+        default=False,
+        alias="includeDeleted",
+        description="Include soft-deleted entities.",
+    )
+    fields: str | None = Field(
+        default=None,
+        description="Comma-separated additional fields (e.g. 'columns,queries').",
+    )
+    include_aggregations: bool = Field(
+        default=False,
+        alias="includeAggregations",
+        description="Include facet aggregations in response.",
+    )
+    max_aggregation_buckets: int | None = Field(
+        default=None,
+        ge=1,
+        le=50,
+        alias="maxAggregationBuckets",
+        description="Max aggregation buckets (max 50).",
+    )
+
+
+class SearchHit(_PermissiveResponse):
+    """A single search result entry."""
+
+    fully_qualified_name: str | None = Field(
+        default=None,
+        alias="fullyQualifiedName",
+    )
+    entity_type: str | None = Field(
+        default=None,
+        alias="entityType",
+    )
+    name: str | None = None
+    description: str | None = None
+    display_name: str | None = Field(default=None, alias="displayName")
+
+
+class SearchMetadataResponse(_PermissiveResponse):
+    """Parsed response from ``search_metadata``.
+
+    The OM server returns search hits under various keys depending on the
+    query.  We capture the common pattern.
+    """
+
+    hits: list[SearchHit] = Field(default_factory=list)
+    total: int = Field(default=0)
+
+
+# =============================================================================
+# Tool 2: get_entity_details
+# =============================================================================
+
+
+class GetEntityDetailsParams(_StrictParams):
+    """Input parameters for the ``get_entity_details`` MCP tool."""
+
+    entity_type: str = Field(
+        ...,
+        alias="entityType",
+        description="Type of entity: table, dashboard, topic, pipeline, etc.",
+    )
+    fqn: str = Field(
+        ...,
+        description="Fully qualified name of the entity.",
+    )
+
+
+class GetEntityDetailsResponse(_PermissiveResponse):
+    """Parsed response from ``get_entity_details``.
+
+    Contains full entity details.  We validate the minimum set of fields we
+    use; additional server fields are captured by ``extra='allow'``.
+    """
+
+    id: str | None = None
+    name: str | None = None
+    fully_qualified_name: str | None = Field(
+        default=None,
+        alias="fullyQualifiedName",
+    )
+    entity_type: str | None = Field(
+        default=None,
+        alias="entityType",
+    )
+    description: str | None = None
+    owners: list[dict[str, Any]] = Field(default_factory=list)
+    tags: list[dict[str, Any]] = Field(default_factory=list)
+    columns: list[dict[str, Any]] = Field(default_factory=list)
+
+
+# =============================================================================
+# Tool 3: get_entity_lineage
+# =============================================================================
+
+
+class GetEntityLineageParams(_StrictParams):
+    """Input parameters for the ``get_entity_lineage`` MCP tool."""
+
+    entity_type: str = Field(
+        ...,
+        alias="entityType",
+        description="Type of entity.",
+    )
+    fqn: str = Field(
+        ...,
+        description="Fully qualified name of the entity.",
+    )
+    upstream_depth: int = Field(
+        default=3,
+        ge=1,
+        le=10,
+        alias="upstreamDepth",
+        description="Upstream hops to traverse (max 10).",
+    )
+    downstream_depth: int = Field(
+        default=3,
+        ge=1,
+        le=10,
+        alias="downstreamDepth",
+        description="Downstream hops to traverse (max 10).",
+    )
+
+
+class LineageEdge(_PermissiveResponse):
+    """A single lineage edge between two nodes."""
+
+    from_entity: str | None = Field(default=None, alias="fromEntity")
+    to_entity: str | None = Field(default=None, alias="toEntity")
+
+
+class LineageNodeInfo(_PermissiveResponse):
+    """A node in the lineage graph."""
+
+    id: str | None = None
+    name: str | None = None
+    fully_qualified_name: str | None = Field(
+        default=None,
+        alias="fullyQualifiedName",
+    )
+    entity_type: str | None = Field(
+        default=None,
+        alias="entityType",
+    )
+
+
+class GetEntityLineageResponse(_PermissiveResponse):
+    """Parsed response from ``get_entity_lineage``."""
+
+    entity: LineageNodeInfo | None = None
+    nodes: list[LineageNodeInfo] = Field(default_factory=list)
+    edges: list[LineageEdge] = Field(default_factory=list)
+    upstream_edges: list[LineageEdge] = Field(
+        default_factory=list,
+        alias="upstreamEdges",
+    )
+    downstream_edges: list[LineageEdge] = Field(
+        default_factory=list,
+        alias="downstreamEdges",
+    )
+
+
+# =============================================================================
+# Tool 4: create_glossary
+# =============================================================================
+
+
+class CreateGlossaryParams(_StrictParams):
+    """Input parameters for the ``create_glossary`` MCP tool."""
+
+    name: str = Field(
+        ...,
+        min_length=1,
+        description="Glossary name.",
+    )
+    description: str = Field(
+        ...,
+        min_length=1,
+        description="Glossary description.",
+    )
+    mutually_exclusive: bool = Field(
+        default=False,
+        alias="mutuallyExclusive",
+        description="Whether child terms are mutually exclusive.",
+    )
+    owners: list[str] | None = Field(
+        default=None,
+        description="OM User or Team names.",
+    )
+    reviewers: list[str] | None = Field(
+        default=None,
+        description="OM User or Team names for approval workflow.",
+    )
+
+
+class CreateGlossaryResponse(_PermissiveResponse):
+    """Parsed response from ``create_glossary``."""
+
+    id: str | None = None
+    name: str | None = None
+    fully_qualified_name: str | None = Field(
+        default=None,
+        alias="fullyQualifiedName",
+    )
+    description: str | None = None
+
+
+# =============================================================================
+# Tool 5: create_glossary_term
+# =============================================================================
+
+
+class CreateGlossaryTermParams(_StrictParams):
+    """Input parameters for the ``create_glossary_term`` MCP tool."""
+
+    glossary: str = Field(
+        ...,
+        min_length=1,
+        description="Parent glossary FQN.",
+    )
+    name: str = Field(
+        ...,
+        min_length=1,
+        description="Term name.",
+    )
+    description: str = Field(
+        ...,
+        min_length=1,
+        description="Term description.",
+    )
+    parent_term: str | None = Field(
+        default=None,
+        alias="parentTerm",
+        description="Parent term FQN for hierarchy.",
+    )
+    owners: list[str] | None = Field(
+        default=None,
+        description="OM User or Team names.",
+    )
+    reviewers: list[str] | None = Field(
+        default=None,
+        description="OM User or Team names for approval workflow.",
+    )
+
+
+class CreateGlossaryTermResponse(_PermissiveResponse):
+    """Parsed response from ``create_glossary_term``."""
+
+    id: str | None = None
+    name: str | None = None
+    fully_qualified_name: str | None = Field(
+        default=None,
+        alias="fullyQualifiedName",
+    )
+    glossary: dict[str, Any] | None = None
+    description: str | None = None
+
+
+# =============================================================================
+# Tool 6: patch_entity
+# =============================================================================
+
+
+class PatchEntityParams(_StrictParams):
+    """Input parameters for the ``patch_entity`` MCP tool.
+
+    ``patch`` is a JSONPatch (RFC 6902) operations string.  The OM server
+    expects it as a JSON-encoded string, not a parsed list.
+    """
+
+    entity_type: str = Field(
+        ...,
+        alias="entityType",
+        description="Entity type to patch.",
+    )
+    fqn: str = Field(
+        ...,
+        description="Fully qualified name of the entity.",
+    )
+    patch: str = Field(
+        ...,
+        min_length=2,
+        description='JSONPatch operations as JSON array string (e.g. \'[{"op":"add",...}]\').',
+    )
+
+
+class PatchEntityResponse(_PermissiveResponse):
+    """Parsed response from ``patch_entity``."""
+
+    id: str | None = None
+    name: str | None = None
+    fully_qualified_name: str | None = Field(
+        default=None,
+        alias="fullyQualifiedName",
+    )
+    entity_type: str | None = Field(
+        default=None,
+        alias="entityType",
+    )
+    description: str | None = None
+    tags: list[dict[str, Any]] = Field(default_factory=list)

--- a/tests/unit/test_mcp_tools.py
+++ b/tests/unit/test_mcp_tools.py
@@ -1,0 +1,521 @@
+#  Copyright 2026 Collate Inc.
+#  Licensed under the Apache License, Version 2.0 (the "License"); you may
+#  not use this file except in compliance with the License. You may obtain
+#  a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Unit tests for copilot.models.mcp_tools and typed wrappers in om_mcp.
+
+Tests cover:
+  - Params validation: required fields, type coercion, alias mapping, defaults
+  - Response parsing: happy path, extra fields ignored, missing optional fields
+  - Typed wrapper functions: mock call_tool, verify Params→dict→Response round-trip
+  - Edge cases: empty results, validation errors
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from pydantic import ValidationError
+
+from copilot.models.mcp_tools import (
+    CreateGlossaryParams,
+    CreateGlossaryResponse,
+    CreateGlossaryTermParams,
+    CreateGlossaryTermResponse,
+    GetEntityDetailsParams,
+    GetEntityDetailsResponse,
+    GetEntityLineageParams,
+    GetEntityLineageResponse,
+    PatchEntityParams,
+    PatchEntityResponse,
+    SearchMetadataParams,
+    SearchMetadataResponse,
+)
+
+# =============================================================================
+# Params validation tests
+# =============================================================================
+
+
+class TestSearchMetadataParams:
+    """Tests for SearchMetadataParams validation."""
+
+    def test_defaults_only(self) -> None:
+        """All params are optional; defaults produce a valid model."""
+        params = SearchMetadataParams()
+
+        assert params.query is None
+        assert params.entity_type is None
+        assert params.from_ == 0
+        assert params.size == 10
+        assert params.include_deleted is False
+
+    def test_all_fields(self) -> None:
+        """All fields set explicitly."""
+        params = SearchMetadataParams(
+            query="customer",
+            entity_type="table",
+            from_=10,
+            size=50,
+            include_deleted=True,
+            fields="columns,queries",
+            include_aggregations=True,
+            max_aggregation_buckets=20,
+        )
+
+        assert params.query == "customer"
+        assert params.entity_type == "table"
+        assert params.from_ == 10
+        assert params.size == 50
+
+    def test_alias_serialization(self) -> None:
+        """Serialization uses camelCase aliases for SDK compatibility."""
+        params = SearchMetadataParams(
+            entity_type="table",
+            include_deleted=True,
+        )
+        dumped = params.model_dump(by_alias=True, exclude_none=True)
+
+        assert "entityType" in dumped
+        assert "includeDeleted" in dumped
+        assert dumped["entityType"] == "table"
+        assert dumped["includeDeleted"] is True
+
+    def test_size_validation_max(self) -> None:
+        """Size > 50 is rejected."""
+        with pytest.raises(ValidationError, match="less than or equal to 50"):
+            SearchMetadataParams(size=51)
+
+    def test_size_validation_min(self) -> None:
+        """Size < 1 is rejected."""
+        with pytest.raises(ValidationError, match="greater than or equal to 1"):
+            SearchMetadataParams(size=0)
+
+    def test_extra_fields_rejected(self) -> None:
+        """Extra fields are rejected (strict params)."""
+        with pytest.raises(ValidationError, match="extra"):
+            SearchMetadataParams(unknown_field="value")  # type: ignore[call-arg]
+
+    def test_none_fields_excluded(self) -> None:
+        """None fields are excluded from dump when exclude_none=True."""
+        params = SearchMetadataParams(query="test")
+        dumped = params.model_dump(by_alias=True, exclude_none=True)
+
+        assert "entityType" not in dumped
+        assert "queryFilter" not in dumped
+        assert "query" in dumped
+
+
+class TestGetEntityDetailsParams:
+    """Tests for GetEntityDetailsParams validation."""
+
+    def test_required_fields(self) -> None:
+        """entityType and fqn are required."""
+        params = GetEntityDetailsParams(
+            entity_type="table",
+            fqn="service.db.schema.table",
+        )
+        assert params.entity_type == "table"
+        assert params.fqn == "service.db.schema.table"
+
+    def test_missing_required_raises(self) -> None:
+        """Missing required fields raises ValidationError."""
+        with pytest.raises(ValidationError):
+            GetEntityDetailsParams()  # type: ignore[call-arg]
+
+    def test_alias_dump(self) -> None:
+        """Dump produces camelCase alias."""
+        params = GetEntityDetailsParams(entity_type="table", fqn="test.table")
+        dumped = params.model_dump(by_alias=True)
+
+        assert dumped["entityType"] == "table"
+        assert dumped["fqn"] == "test.table"
+
+
+class TestGetEntityLineageParams:
+    """Tests for GetEntityLineageParams validation."""
+
+    def test_defaults(self) -> None:
+        """Depth defaults to 3."""
+        params = GetEntityLineageParams(entity_type="table", fqn="a.b.c")
+
+        assert params.upstream_depth == 3
+        assert params.downstream_depth == 3
+
+    def test_depth_max_validation(self) -> None:
+        """Depth > 10 is rejected."""
+        with pytest.raises(ValidationError, match="less than or equal to 10"):
+            GetEntityLineageParams(
+                entity_type="table",
+                fqn="a.b.c",
+                upstream_depth=11,
+            )
+
+
+class TestCreateGlossaryParams:
+    """Tests for CreateGlossaryParams validation."""
+
+    def test_required_fields(self) -> None:
+        """name and description are required."""
+        params = CreateGlossaryParams(
+            name="Governance",
+            description="Core governance glossary",
+        )
+        assert params.name == "Governance"
+        assert params.mutually_exclusive is False
+
+    def test_empty_name_rejected(self) -> None:
+        """Empty name is rejected."""
+        with pytest.raises(ValidationError, match="at least 1"):
+            CreateGlossaryParams(name="", description="test")
+
+    def test_optional_owners(self) -> None:
+        """owners is optional."""
+        params = CreateGlossaryParams(
+            name="Test",
+            description="Test glossary",
+            owners=["admin", "team_lead"],
+        )
+        assert params.owners == ["admin", "team_lead"]
+
+
+class TestCreateGlossaryTermParams:
+    """Tests for CreateGlossaryTermParams validation."""
+
+    def test_required_fields(self) -> None:
+        """glossary, name, description are required."""
+        params = CreateGlossaryTermParams(
+            glossary="Governance",
+            name="PII",
+            description="Personally Identifiable Information",
+        )
+        assert params.glossary == "Governance"
+
+    def test_parent_term_alias(self) -> None:
+        """parentTerm alias works correctly."""
+        params = CreateGlossaryTermParams(
+            glossary="Governance",
+            name="Email",
+            description="Email address",
+            parent_term="Governance.PII",
+        )
+        dumped = params.model_dump(by_alias=True, exclude_none=True)
+
+        assert dumped["parentTerm"] == "Governance.PII"
+
+
+class TestPatchEntityParams:
+    """Tests for PatchEntityParams validation."""
+
+    def test_required_fields(self) -> None:
+        """entityType, fqn, patch are all required."""
+        params = PatchEntityParams(
+            entity_type="table",
+            fqn="db.schema.users",
+            patch='[{"op": "add", "path": "/tags/0", "value": {"tagFQN": "PII.Sensitive"}}]',
+        )
+        assert params.entity_type == "table"
+
+    def test_patch_min_length(self) -> None:
+        """patch must be at least 2 chars (shortest valid: '[]')."""
+        with pytest.raises(ValidationError, match="at least 2"):
+            PatchEntityParams(entity_type="table", fqn="test", patch="")
+
+
+# =============================================================================
+# Response parsing tests
+# =============================================================================
+
+
+class TestSearchMetadataResponse:
+    """Tests for SearchMetadataResponse parsing."""
+
+    def test_parse_happy_path(self) -> None:
+        """Parse a response with hits."""
+        raw = {
+            "hits": [
+                {"fullyQualifiedName": "db.users", "entityType": "table", "name": "users"},
+            ],
+            "total": 1,
+        }
+        resp = SearchMetadataResponse.model_validate(raw)
+
+        assert resp.total == 1
+        assert len(resp.hits) == 1
+        assert resp.hits[0].fully_qualified_name == "db.users"
+
+    def test_parse_empty_results(self) -> None:
+        """Empty results produce empty hits."""
+        resp = SearchMetadataResponse.model_validate({"hits": [], "total": 0})
+        assert resp.total == 0
+        assert resp.hits == []
+
+    def test_extra_fields_preserved(self) -> None:
+        """Extra server fields are silently accepted."""
+        raw = {"hits": [], "total": 0, "took_ms": 42, "aggregations": {}}
+        resp = SearchMetadataResponse.model_validate(raw)
+        assert resp.total == 0
+
+
+class TestGetEntityDetailsResponse:
+    """Tests for GetEntityDetailsResponse parsing."""
+
+    def test_parse_happy_path(self) -> None:
+        """Parse a full entity response."""
+        raw = {
+            "id": "abc-123",
+            "name": "users",
+            "fullyQualifiedName": "pg.public.users",
+            "entityType": "table",
+            "description": "User accounts table",
+            "owners": [{"name": "admin"}],
+            "tags": [{"tagFQN": "PII.Sensitive"}],
+            "columns": [{"name": "email", "dataType": "VARCHAR"}],
+        }
+        resp = GetEntityDetailsResponse.model_validate(raw)
+
+        assert resp.id == "abc-123"
+        assert resp.fully_qualified_name == "pg.public.users"
+        assert len(resp.tags) == 1
+        assert len(resp.columns) == 1
+
+    def test_minimal_response(self) -> None:
+        """Response with only optional fields missing."""
+        resp = GetEntityDetailsResponse.model_validate({})
+
+        assert resp.id is None
+        assert resp.owners == []
+        assert resp.tags == []
+        assert resp.columns == []
+
+
+class TestGetEntityLineageResponse:
+    """Tests for GetEntityLineageResponse parsing."""
+
+    def test_parse_with_edges(self) -> None:
+        """Parse lineage with nodes and edges."""
+        raw = {
+            "entity": {"id": "1", "name": "users", "fullyQualifiedName": "db.users"},
+            "nodes": [{"id": "2", "name": "orders"}],
+            "edges": [{"fromEntity": "1", "toEntity": "2"}],
+        }
+        resp = GetEntityLineageResponse.model_validate(raw)
+
+        assert resp.entity is not None
+        assert resp.entity.name == "users"
+        assert len(resp.nodes) == 1
+        assert len(resp.edges) == 1
+
+
+class TestCreateGlossaryResponse:
+    """Tests for CreateGlossaryResponse parsing."""
+
+    def test_parse_happy_path(self) -> None:
+        """Parse a created glossary."""
+        raw = {
+            "id": "gl-1",
+            "name": "Governance",
+            "fullyQualifiedName": "Governance",
+            "description": "Core governance glossary",
+        }
+        resp = CreateGlossaryResponse.model_validate(raw)
+
+        assert resp.name == "Governance"
+        assert resp.fully_qualified_name == "Governance"
+
+
+class TestPatchEntityResponse:
+    """Tests for PatchEntityResponse parsing."""
+
+    def test_parse_with_tags(self) -> None:
+        """Parse a patched entity with tags."""
+        raw = {
+            "id": "tbl-1",
+            "name": "users",
+            "fullyQualifiedName": "db.users",
+            "entityType": "table",
+            "tags": [{"tagFQN": "PII.Sensitive", "source": "Manual"}],
+        }
+        resp = PatchEntityResponse.model_validate(raw)
+
+        assert len(resp.tags) == 1
+        assert resp.entity_type == "table"
+
+
+# =============================================================================
+# Typed wrapper function tests
+# =============================================================================
+
+
+class TestSearchMetadataTyped:
+    """Tests for search_metadata_typed wrapper."""
+
+    @patch("copilot.clients.om_mcp.call_tool")
+    def test_happy_path(self, mock_call: Any) -> None:
+        """Params are serialized, call_tool called, response parsed."""
+        from copilot.clients.om_mcp import search_metadata_typed
+
+        mock_call.return_value = {
+            "hits": [{"fullyQualifiedName": "db.users", "entityType": "table"}],
+            "total": 1,
+        }
+        params = SearchMetadataParams(query="users", entity_type="table", size=5)
+        result = search_metadata_typed(params)
+
+        mock_call.assert_called_once_with(
+            "search_metadata",
+            {"query": "users", "entityType": "table", "size": 5, "from": 0,
+             "includeDeleted": False, "includeAggregations": False},
+        )
+        assert isinstance(result, SearchMetadataResponse)
+        assert result.total == 1
+        assert result.hits[0].fully_qualified_name == "db.users"
+
+    @patch("copilot.clients.om_mcp.call_tool")
+    def test_empty_results(self, mock_call: Any) -> None:
+        """Empty results from server produce empty response."""
+        from copilot.clients.om_mcp import search_metadata_typed
+
+        mock_call.return_value = {"hits": [], "total": 0}
+        params = SearchMetadataParams(query="nonexistent")
+        result = search_metadata_typed(params)
+
+        assert result.total == 0
+        assert result.hits == []
+
+
+class TestGetEntityDetailsTyped:
+    """Tests for get_entity_details_typed wrapper."""
+
+    @patch("copilot.clients.om_mcp.call_tool")
+    def test_happy_path(self, mock_call: Any) -> None:
+        """Full entity details returned and parsed."""
+        from copilot.clients.om_mcp import get_entity_details_typed
+
+        mock_call.return_value = {
+            "id": "abc",
+            "name": "users",
+            "fullyQualifiedName": "pg.public.users",
+            "entityType": "table",
+            "columns": [{"name": "email"}],
+        }
+        params = GetEntityDetailsParams(entity_type="table", fqn="pg.public.users")
+        result = get_entity_details_typed(params)
+
+        mock_call.assert_called_once_with(
+            "get_entity_details",
+            {"entityType": "table", "fqn": "pg.public.users"},
+        )
+        assert isinstance(result, GetEntityDetailsResponse)
+        assert result.fully_qualified_name == "pg.public.users"
+
+
+class TestGetEntityLineageTyped:
+    """Tests for get_entity_lineage_typed wrapper."""
+
+    @patch("copilot.clients.om_mcp.call_tool")
+    def test_happy_path(self, mock_call: Any) -> None:
+        """Lineage graph returned and parsed."""
+        from copilot.clients.om_mcp import get_entity_lineage_typed
+
+        mock_call.return_value = {
+            "entity": {"id": "1", "name": "users"},
+            "nodes": [],
+            "edges": [],
+        }
+        params = GetEntityLineageParams(entity_type="table", fqn="db.users")
+        result = get_entity_lineage_typed(params)
+
+        mock_call.assert_called_once_with(
+            "get_entity_lineage",
+            {"entityType": "table", "fqn": "db.users", "upstreamDepth": 3, "downstreamDepth": 3},
+        )
+        assert isinstance(result, GetEntityLineageResponse)
+
+
+class TestCreateGlossaryTyped:
+    """Tests for create_glossary_typed wrapper."""
+
+    @patch("copilot.clients.om_mcp.call_tool")
+    def test_happy_path(self, mock_call: Any) -> None:
+        """Glossary created and response parsed."""
+        from copilot.clients.om_mcp import create_glossary_typed
+
+        mock_call.return_value = {
+            "id": "gl-1",
+            "name": "Governance",
+            "fullyQualifiedName": "Governance",
+        }
+        params = CreateGlossaryParams(name="Governance", description="Test")
+        result = create_glossary_typed(params)
+
+        assert isinstance(result, CreateGlossaryResponse)
+        assert result.name == "Governance"
+
+
+class TestCreateGlossaryTermTyped:
+    """Tests for create_glossary_term_typed wrapper."""
+
+    @patch("copilot.clients.om_mcp.call_tool")
+    def test_happy_path(self, mock_call: Any) -> None:
+        """Glossary term created and response parsed."""
+        from copilot.clients.om_mcp import create_glossary_term_typed
+
+        mock_call.return_value = {
+            "id": "gt-1",
+            "name": "PII",
+            "fullyQualifiedName": "Governance.PII",
+            "glossary": {"name": "Governance"},
+        }
+        params = CreateGlossaryTermParams(
+            glossary="Governance",
+            name="PII",
+            description="Personally Identifiable Information",
+        )
+        result = create_glossary_term_typed(params)
+
+        assert isinstance(result, CreateGlossaryTermResponse)
+        assert result.fully_qualified_name == "Governance.PII"
+
+
+class TestPatchEntityTyped:
+    """Tests for patch_entity_typed wrapper."""
+
+    @patch("copilot.clients.om_mcp.call_tool")
+    def test_happy_path(self, mock_call: Any) -> None:
+        """Entity patched and response parsed."""
+        from copilot.clients.om_mcp import patch_entity_typed
+
+        mock_call.return_value = {
+            "id": "tbl-1",
+            "name": "users",
+            "fullyQualifiedName": "db.users",
+            "tags": [{"tagFQN": "PII.Sensitive"}],
+        }
+        params = PatchEntityParams(
+            entity_type="table",
+            fqn="db.users",
+            patch='[{"op": "add", "path": "/tags/0", "value": {"tagFQN": "PII.Sensitive"}}]',
+        )
+        result = patch_entity_typed(params)
+
+        mock_call.assert_called_once_with(
+            "patch_entity",
+            {
+                "entityType": "table",
+                "fqn": "db.users",
+                "patch": '[{"op": "add", "path": "/tags/0", "value": {"tagFQN": "PII.Sensitive"}}]',
+            },
+        )
+        assert isinstance(result, PatchEntityResponse)
+        assert len(result.tags) == 1


### PR DESCRIPTION
## Summary

Add Pydantic v2 typed `Params` and `Response` models for the top 6 MCP tools, plus typed wrapper functions in `om_mcp.py`. This catches bugs at the SDK boundary instead of deep inside business logic.

Closes #22

## Changes

### New Files

- **`src/copilot/models/mcp_tools.py`** — 12 Pydantic v2 models:
  - `SearchMetadataParams` / `SearchMetadataResponse`
  - `GetEntityDetailsParams` / `GetEntityDetailsResponse`
  - `GetEntityLineageParams` / `GetEntityLineageResponse`
  - `CreateGlossaryParams` / `CreateGlossaryResponse`
  - `CreateGlossaryTermParams` / `CreateGlossaryTermResponse`
  - `PatchEntityParams` / `PatchEntityResponse`

- **`tests/unit/test_mcp_tools.py`** — 34 unit tests covering:
  - Params validation (required fields, type coercion, `extra='forbid'`)
  - Alias serialization (snake_case Python → camelCase SDK)
  - Response parsing (happy path, empty results, extra fields)
  - 6 typed wrapper round-trip tests (mock `call_tool`)

### Modified Files

- **`src/copilot/clients/om_mcp.py`** — 6 typed wrapper functions:
  - `search_metadata_typed(params) -> SearchMetadataResponse`
  - `get_entity_details_typed(params) -> GetEntityDetailsResponse`
  - `get_entity_lineage_typed(params) -> GetEntityLineageResponse`
  - `create_glossary_typed(params) -> CreateGlossaryResponse`
  - `create_glossary_term_typed(params) -> CreateGlossaryTermResponse`
  - `patch_entity_typed(params) -> PatchEntityResponse`

- **`src/copilot/models/__init__.py`** — re-exports all 12 new classes

## Design Decisions

1. **Params use `extra='forbid'`** — strict validation catches typos in argument names at construction time
2. **Response use `extra='allow'`** — permissive to tolerate OM server adding new fields without breaking
3. **snake_case fields with camelCase aliases** — Python-idiomatic API, SDK-compatible serialization via `model_dump(by_alias=True)`
4. **Typed wrappers call existing `call_tool`** — reuses retry + circuit breaker + metrics already in place

## Verification

- [x] `pytest tests/unit/test_mcp_tools.py -v` — **34 passed** (0.75s)
- [x] `pytest tests/unit/ -v` — **72 passed** (3.67s), zero regressions
- [x] `mypy --strict src/copilot/models/mcp_tools.py` — **Success: no issues found**
- [x] `ruff check` — **All checks passed** (after auto-fix of import sorting)

## Depends on

- #16 (MCP client, merged in PR #55) ✅
- #21 (tool schemas documented in ExistingMCPAudit.md) ✅

## Unblocks

- #23 (unit tests for MCP client wrappers — partially covered here with 34 tests)