### PR TITLE
refactor: move cast import to module top-level in om_mcp.py

### DIFF
--- a/src/copilot/clients/om_mcp.py
+++ b/src/copilot/clients/om_mcp.py
@@ -32,7 +32,7 @@ from __future__ import annotations
 import contextlib
 import time
 from functools import lru_cache
-from typing import Any
+from typing import Any, cast
 
 import pybreaker
 from ai_sdk.mcp._client import MCPError  # type: ignore[attr-defined, unused-ignore]
@@ -165,8 +165,6 @@ def call_tool(name: str, arguments: dict[str, Any]) -> dict[str, Any]:
     elapsed_ms = int((time.monotonic() - start) * 1000)
     log.info("om.call_tool.complete", tool=name, elapsed_ms=elapsed_ms)
     agent_mcp_calls_total.labels(tool_name=name, outcome="ok").inc()
-    from typing import cast
-
     return cast(dict[str, Any], result)
 
 


### PR DESCRIPTION
**Follow-up from PR #68 review.**

Moves `from typing import cast` from inside the `call_tool()` function body (line 168) to the module top-level imports alongside `from typing import Any`.

### Why
- `call_tool()` is a runtime-hot path invoked on every MCP tool call
- Python caches module imports, but placing imports inside hot-path function bodies is non-idiomatic
- The `typing` module is already imported at module level; extending the import is trivial

### Changes
- `src/copilot/clients/om_mcp.py`: `from typing import Any` → `from typing import Any, cast`; removed `from typing import cast` from function body

No behavioral change.