### PR TITLE
Fix mypy strict: om_mcp monkey-patch and agent import

### DIFF
--- a/src/copilot/clients/om_mcp.py
+++ b/src/copilot/clients/om_mcp.py
@@ -35,6 +35,7 @@ from __future__ import annotations
 
 import contextlib
 import time
+from collections.abc import Callable
 from functools import lru_cache
 from typing import Any, cast
 
@@ -83,7 +84,7 @@ log = get_logger(__name__)
 
 # data-ai-sdk hardcodes POST "/mcp" in MCPClient._make_jsonrpc_request. Some OM builds
 # return 405 there; OM_MCP_HTTP_PATH (see Settings.om_mcp_http_path) overrides the path.
-_mcp_jsonrpc_original: Any = None
+_mcp_jsonrpc_original: Callable[..., Any] | None = None
 _mcp_jsonrpc_patched: bool = False
 
 
@@ -93,7 +94,7 @@ def _reset_mcp_jsonrpc_path_patch_for_tests() -> None:
     if _mcp_jsonrpc_original is not None:
         from ai_sdk.mcp import _client as mcp_client_mod  # type: ignore[unused-ignore]
 
-        mcp_client_mod.MCPClient._make_jsonrpc_request = _mcp_jsonrpc_original
+        mcp_client_mod.MCPClient._make_jsonrpc_request = _mcp_jsonrpc_original  # type: ignore[method-assign]
     _mcp_jsonrpc_original = None
     _mcp_jsonrpc_patched = False
     _get_sdk_client.cache_clear()
@@ -113,7 +114,9 @@ def _ensure_mcp_jsonrpc_uses_configured_path() -> None:
 
     _mcp_jsonrpc_original = mcp_client_mod.MCPClient._make_jsonrpc_request
 
-    def _patched_make_jsonrpc_request(self: Any, method: str, params: dict | None = None) -> dict:
+    def _patched_make_jsonrpc_request(
+        self: Any, method: str, params: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
         path = get_settings().om_mcp_http_path
         request_id = str(uuid.uuid4())[:8]
         payload = {
@@ -130,9 +133,9 @@ def _ensure_mcp_jsonrpc_uses_configured_path() -> None:
         if "error" in result:
             raise MCPError(f"MCP error: {result['error'].get('message', 'Unknown error')}")
 
-        return result.get("result", {})
+        return cast(dict[str, Any], result.get("result", {}))
 
-    mcp_client_mod.MCPClient._make_jsonrpc_request = _patched_make_jsonrpc_request
+    mcp_client_mod.MCPClient._make_jsonrpc_request = _patched_make_jsonrpc_request  # type: ignore[method-assign]
     _mcp_jsonrpc_patched = True
 
 

--- a/src/copilot/services/agent.py
+++ b/src/copilot/services/agent.py
@@ -38,7 +38,7 @@ from datetime import UTC, datetime, timedelta
 from typing import Any, Literal
 from uuid import UUID, uuid4
 
-from langgraph.graph import END, StateGraph  # type: ignore[import-untyped]
+from langgraph.graph import END, StateGraph
 from typing_extensions import TypedDict
 
 from copilot.clients import om_mcp, openai_client


### PR DESCRIPTION
### Related Issues

- (none — CI `mypy --strict` regression)

### Proposed Changes

- **`om_mcp.py`**: Satisfy strict mypy for the MCP JSON-RPC path monkey-patch — typed `Callable` holder, `dict[str, Any]` params/return, `cast` on JSON-RPC `result`, and **`# type: ignore[method-assign]`** on the two class-method replacements (Ruff B010 prefers assignment over `setattr`, which would otherwise re-trigger `method-assign`).
- **`agent.py`**: Remove unused **`# type: ignore[import-untyped]`** on the `langgraph` import (`unused-ignore`).

### How I tested

- `python -m mypy --strict src/copilot`
- `pre-commit run --files src/copilot/clients/om_mcp.py src/copilot/services/agent.py`
- `python -m pytest tests/unit/test_om_mcp.py -q` (spot-check MCP tests)

### Checklist

- [x] mypy strict clean
- [x] pre-commit on touched files
