### PR TITLE
fix: lineage impact analysis summary and tier warnings

### DIFF
--- a/.idea/Plan/Architecture/DataFlow.md
+++ b/.idea/Plan/Architecture/DataFlow.md
@@ -19,7 +19,7 @@ sequenceDiagram
     API->>A: run_chat_turn
     A->>LLM: intent + tool selection
     LLM-->>A: read tool proposal
-    A->>MCP: search_metadata / get_entity_details
+    A->>MCP: search_metadata / get_entity_details / get_entity_lineage
     MCP->>OM: REST / search
     OM-->>MCP: JSON
     MCP-->>A: structured result

--- a/.idea/Plan/FeatureDev/LineageImpact.md
+++ b/.idea/Plan/FeatureDev/LineageImpact.md
@@ -34,7 +34,6 @@ User: "Show me the upstream of the revenue_dashboard"
    4. pricing_rules (Snowflake) → via products
 
    ⚠️ Cross-service dependency: pricing_rules is in Snowflake while others are in BigQuery."
-```
 
 ## MCP Tools Used
 

--- a/.idea/Plan/FeatureDev/LineageImpact.md
+++ b/.idea/Plan/FeatureDev/LineageImpact.md
@@ -22,6 +22,7 @@ User: "What breaks if I drop the customers table?"
    - 3 tables (customer_metrics, customer_segments, customer_ltv)
 
    Critical impact: customer_360 dashboard is Tier 1 and owned by the exec team."
+```
 
 User: "Show me the upstream of the revenue_dashboard"
 → Agent calls get_entity_lineage(fqn="...", upstreamDepth=5)
@@ -59,6 +60,10 @@ Rules:
 3. Note any data quality test failures on downstream assets
 4. Be concise — no more than 10 lines
 ```
+
+## Done when
+
+- [x] Lineage intent returns human-readable report with Tier warnings.
 
 ## Error Handling
 

--- a/src/copilot/services/agent.py
+++ b/src/copilot/services/agent.py
@@ -635,6 +635,16 @@ async def format_response(state: AgentState) -> AgentState:
                 )
                 break
 
+    # Lineage impact report instructions
+    if intent == "lineage" and results:
+        context_parts.append(
+            "\nIMPORTANT: Lineage Impact Analysis rules:\n"
+            "1. List affected assets grouped by type (tables, dashboards, pipelines).\n"
+            "2. Highlight Tier 1 assets and cross-service dependencies.\n"
+            "3. Note any data quality test failures on downstream assets.\n"
+            "4. Be concise — no more than 10 lines."
+        )
+
     # Similarity scoring
     candidate_fqns = []
     for proposal in state.get("tool_proposals", []) + ([pending] if pending else []):

--- a/tests/unit/test_agent.py
+++ b/tests/unit/test_agent.py
@@ -501,7 +501,7 @@ class TestFormatResponse:
         messages = call_kwargs.get("messages") or mock_llm.call_args[0][0]
         system_call_content = messages[1]["content"]
         assert "Opinionated Governance Assistant:" in system_call_content
- 
+
     @patch("copilot.services.agent.openai_client.call_chat", new_callable=AsyncMock)
     async def test_injects_lineage_report_prompt(
         self, mock_llm: AsyncMock, base_state: AgentState
@@ -511,15 +511,14 @@ class TestFormatResponse:
         base_state["intent"] = "lineage"
         base_state["tool_results"] = [{"nodes": [], "edges": []}]
         await format_response(base_state)
- 
+
         call_kwargs = (
             mock_llm.call_args.kwargs if mock_llm.call_args.kwargs else mock_llm.call_args[1]
         )
         messages = call_kwargs.get("messages") or mock_llm.call_args[0][0]
-        # The instructions are in the user message (messages[1]) which is context_parts
-        system_call_content = messages[1]["content"]
-        assert "Lineage Impact Analysis rules" in system_call_content
-        assert "Tier 1 assets" in system_call_content
+        user_context = messages[1]["content"]
+        assert "Lineage Impact Analysis rules" in user_context
+        assert "Tier 1 assets" in user_context
 
 
 class TestRunChatTurn:

--- a/tests/unit/test_agent.py
+++ b/tests/unit/test_agent.py
@@ -471,6 +471,25 @@ class TestFormatResponse:
         messages = call_kwargs.get("messages") or mock_llm.call_args[0][0]
         system_call_content = messages[1]["content"]
         assert "Opinionated Governance Assistant:" in system_call_content
+ 
+    @patch("copilot.services.agent.openai_client.call_chat", new_callable=AsyncMock)
+    async def test_injects_lineage_report_prompt(
+        self, mock_llm: AsyncMock, base_state: AgentState
+    ) -> None:
+        """If lineage intent and results present, formatting context includes lineage impact rules."""
+        mock_llm.return_value = {"content": "ok", "tokens_prompt": 1, "tokens_completion": 1}
+        base_state["intent"] = "lineage"
+        base_state["tool_results"] = [{"nodes": [], "edges": []}]
+        await format_response(base_state)
+ 
+        call_kwargs = (
+            mock_llm.call_args.kwargs if mock_llm.call_args.kwargs else mock_llm.call_args[1]
+        )
+        messages = call_kwargs.get("messages") or mock_llm.call_args[0][0]
+        # The instructions are in the user message (messages[1]) which is context_parts
+        system_call_content = messages[1]["content"]
+        assert "Lineage Impact Analysis rules" in system_call_content
+        assert "Tier 1 assets" in system_call_content
 
 
 class TestRunChatTurn:


### PR DESCRIPTION
Fixes #81

### Root Cause
The agent was using a generic response formatter for lineage results, which didn't provide enough structure for impact analysis (Tiers, cross-service dependencies, etc.).

### Changes
- **Agent Service**: Enhanced `format_response` in `agent.py` to inject specialized instructions for the `lineage` intent.
- **Documentation**: Updated `LineageImpact.md` (completed) and `DataFlow.md` (read path diagram).
- **Tests**: Added `test_injects_lineage_report_prompt` to `test_agent.py`.

### Verification
- Ran `make test-unit` (221 passing).
- Verified specialized instructions are correctly injected into the LLM context when intent is 'lineage'.
