### PR TITLE
fix(api): CORS for Vite dev at 127.0.0.1:3000

### DIFF
--- a/src/copilot/api/main.py
+++ b/src/copilot/api/main.py
@@ -78,7 +78,10 @@ def create_app() -> FastAPI:
     app.add_middleware(RequestIdMiddleware)
     app.add_middleware(
         CORSMiddleware,
-        allow_origins=["http://localhost:3000"],
+        allow_origins=[
+            "http://localhost:3000",
+            "http://127.0.0.1:3000",
+        ],
         allow_credentials=False,
         allow_methods=["GET", "POST", "OPTIONS"],
         allow_headers=["Content-Type", "X-Request-Id"],


### PR DESCRIPTION
Vite prints Local: http://127.0.0.1:3000/ but CORSMiddleware only allowed localhost:3000, so browser chat fetches failed when using the default dev URL.

Made with [Cursor](https://cursor.com)