### PR TITLE
fix: OM drift auth, MCP results shape, chat format short-circuits

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,7 @@ AI_SDK_HOST=http://localhost:8585
 
 # AI_SDK_TOKEN: Bot JWT for the agent's MCP calls (required — invalid JWT → 401 from OM).
 # Generate via: ``make om-gen-token`` or OM UI -> Settings -> Bots -> ingestion-bot.
+# Paste the token only (no leading ``Bearer `` — the SDK adds that header).
 # Replace the entire line; do not commit the real token.
 AI_SDK_TOKEN=paste-your-bot-jwt-here
 

--- a/scripts/diagnose_om_mcp_auth.py
+++ b/scripts/diagnose_om_mcp_auth.py
@@ -1,0 +1,76 @@
+#  Copyright 2026 Collate Inc.
+#  Licensed under the Apache License, Version 2.0 (the "License"); you may
+#  not use this file except in compliance with the License. You may obtain
+#  a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+"""Check OpenMetadata MCP auth using repo-root ``.env`` (no secrets printed).
+
+Usage (from repo root)::
+
+    python scripts/diagnose_om_mcp_auth.py
+
+Exit code 0 if ``list_tools`` and a drift-style ``search_metadata`` call succeed;
+1 otherwise. Prints only lengths and status.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+ROOT = Path(__file__).resolve().parent.parent
+load_dotenv(ROOT / ".env")
+
+# Ensure pytest-only guards do not skip validation when run manually.
+os.environ.pop("PYTEST_VERSION", None)
+
+
+def main() -> int:
+    from copilot.clients import om_mcp
+    from copilot.config.settings import get_settings
+
+    get_settings.cache_clear()
+    om_mcp._get_sdk_client.cache_clear()
+
+    s = get_settings()
+    tok = s.ai_sdk_token.get_secret_value()
+    print(f"AI_SDK_HOST={s.ai_sdk_host!r}")
+    print(f"OM_MCP_HTTP_PATH={s.om_mcp_http_path!r}")
+    print(f"AI_SDK_TOKEN length after normalization={len(tok)}")
+    if not tok:
+        print("ERROR: AI_SDK_TOKEN is empty after load.", file=sys.stderr)
+        return 1
+    kind = "fernet" if tok.startswith("fernet:") else ("jwt" if tok.startswith("eyJ") else "other")
+    print(f"AI_SDK_TOKEN shape={kind!r}")
+
+    # Bot JWT is validated by OM on MCP and many REST routes; ``/users/loggedIn`` may
+    # return 404 for bot tokens and is not used as a signal here.
+
+    try:
+        names = om_mcp.list_tools()
+    except Exception as exc:
+        print(f"MCP list_tools FAILED: {type(exc).__name__}: {exc}", file=sys.stderr)
+        return 1
+
+    print(f"MCP list_tools OK: {len(names)} tool(s)")
+
+    try:
+        raw = om_mcp.call_tool("search_metadata", {"query": "*", "limit": 100})
+    except Exception as exc:
+        print(f"MCP search_metadata FAILED: {type(exc).__name__}: {exc}", file=sys.stderr)
+        return 1
+
+    hits = raw.get("hits", raw.get("data", raw.get("results", [])))
+    if isinstance(hits, dict):
+        hits = hits.get("hits", [])
+    n = len(hits) if isinstance(hits, list) else 0
+    print(f"MCP search_metadata OK: {n} hit(s) in normalised response")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/generate_bot_jwt.py
+++ b/scripts/generate_bot_jwt.py
@@ -223,7 +223,7 @@ def generate_token(
         print("FAIL: could not generate bot JWT", file=sys.stderr)
         return None
 
-    jwt_token = result.get("JWTToken") or result.get("token")
+    jwt_token = result.get("JWTToken") or result.get("jwtToken") or result.get("token")
     if not isinstance(jwt_token, str) or not jwt_token:
         print(
             f"FAIL: generateToken response missing JWTToken. Keys: {list(result.keys())}",

--- a/src/copilot/api/governance.py
+++ b/src/copilot/api/governance.py
@@ -45,7 +45,13 @@ async def get_drift(_request: Request) -> JSONResponse:
 
     # If the last scan hit an MCP error, return 503 per APIContract
     if snapshot.error is not None:
-        log.info("governance.drift.unavailable", error=snapshot.error)
+        log.info(
+            "governance.drift.unavailable",
+            error=snapshot.error,
+            auth_failed=snapshot.auth_failed,
+        )
+        if snapshot.auth_failed:
+            return _envelope(ErrorCode.OM_AUTH_FAILED, _request)
         return _envelope(ErrorCode.OM_UNAVAILABLE, _request)
 
     payload = {

--- a/src/copilot/clients/om_mcp.py
+++ b/src/copilot/clients/om_mcp.py
@@ -292,8 +292,18 @@ def _call_tool_inner(name: str, arguments: dict[str, Any]) -> dict[str, Any]:
     except MCPToolExecutionError as exc:
         raise McpUnavailable(f"Tool {name} execution failed: {exc}") from exc
     except MCPError as exc:
+        _cause = getattr(exc, "__cause__", None)
+        from ai_sdk.exceptions import AuthenticationError  # type: ignore[import-untyped]
+
+        if isinstance(_cause, AuthenticationError):
+            raise McpAuthFailed(f"OM auth failed for tool {name}") from exc
         err_msg = str(exc).lower()
-        if "401" in err_msg or "403" in err_msg or "unauthorized" in err_msg:
+        if (
+            "401" in err_msg
+            or "403" in err_msg
+            or "unauthorized" in err_msg
+            or "invalid or expired authentication" in err_msg
+        ):
             raise McpAuthFailed(f"OM auth failed for tool {name}") from exc
         raise McpUnavailable(f"MCP error calling {name}: {exc}") from exc
     except pybreaker.CircuitBreakerError as exc:
@@ -382,7 +392,7 @@ def search_metadata_typed(params: SearchMetadataParams) -> SearchMetadataRespons
 
     # The OM server returns search hits under various shapes.  Normalise to
     # the ``hits`` / ``total`` structure our response model expects.
-    hits_raw = raw.get("hits", raw.get("data", []))
+    hits_raw = raw.get("hits", raw.get("data", raw.get("results", [])))
     if isinstance(hits_raw, dict):
         hits_raw = hits_raw.get("hits", [])
     total = raw.get("total", raw.get("totalCount", len(hits_raw)))

--- a/src/copilot/config/settings.py
+++ b/src/copilot/config/settings.py
@@ -23,9 +23,15 @@ from __future__ import annotations
 import os
 import re
 from functools import lru_cache
+from pathlib import Path
 
 from pydantic import Field, SecretStr, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+# Repo root (directory containing ``src/``). ``env_file=".env"`` is cwd-relative;
+# uvicorn started from ``ui/`` or another cwd would miss the real ``.env`` and get 401 on MCP.
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+_DOTENV_PATH = _REPO_ROOT / ".env"
 
 # Substrings that indicate the user copied .env.example without replacing secrets.
 _ENV_PLACEHOLDER_MARKERS = (
@@ -76,7 +82,7 @@ class Settings(BaseSettings):
     """
 
     model_config = SettingsConfigDict(
-        env_file=".env",
+        env_file=str(_DOTENV_PATH),
         env_file_encoding="utf-8",
         case_sensitive=False,
         extra="ignore",
@@ -95,6 +101,20 @@ class Settings(BaseSettings):
         default=None,
         description="GitHub PAT for the multi-MCP demo (Phase 3 only)",
     )
+
+    @field_validator("ai_sdk_token", mode="before")
+    @classmethod
+    def _normalize_ai_sdk_token(cls, value: object) -> object:
+        """Strip BOM, quotes, and accidental ``Bearer `` prefix (SDK adds Bearer itself)."""
+        if value is None or value == "":
+            return value
+        if not isinstance(value, str):
+            return value
+        cleaned = _normalize_env_secret(value)
+        lower = cleaned.lower()
+        if lower.startswith("bearer "):
+            cleaned = cleaned[7:].strip()
+        return cleaned
 
     @field_validator("github_token", mode="before")
     @classmethod

--- a/src/copilot/services/agent.py
+++ b/src/copilot/services/agent.py
@@ -629,9 +629,65 @@ Rules:
 - Use bullet points for lists
 - Be concise but informative
 - If results are empty, say so clearly
+- If there are no tool results and the user sent only a greeting or a short unclear message,
+  respond with a friendly introduction and **3-4 example queries** (e.g. search tables,
+  describe an entity by FQN, lineage). Do **not** invent errors, timeouts, or internal failures.
 - Never expose internal tool names, raw JSON, or error details to the user
 - If there's a pending confirmation needed, mention it clearly
 """
+
+
+def _mcp_error_codes_from_records(tool_records: list[Any]) -> set[str]:
+    """Collect ``error_code`` values from serialized tool audit records."""
+    codes: set[str] = set()
+    for rec in tool_records:
+        if isinstance(rec, dict):
+            code = rec.get("error_code")
+            if isinstance(code, str):
+                codes.add(code)
+    return codes
+
+
+def _infer_om_issue_from_tool_results(
+    tool_results: list[Any],
+) -> Literal["auth", "unavailable", None]:
+    """Best-effort OM failure classification from raw tool error strings.
+
+    Used when ``error_code`` on audit records is missing but the executor still
+    appended ``{"error": "..."}`` (e.g. older graph state or partial serialization).
+    """
+    for item in tool_results:
+        if not isinstance(item, dict):
+            continue
+        raw = item.get("error")
+        if raw is None:
+            continue
+        err = str(raw).lower()
+        if any(
+            sub in err
+            for sub in (
+                "auth",
+                "401",
+                "403",
+                "unauthorized",
+                "invalid or expired authentication",
+                "om auth failed",
+            )
+        ):
+            return "auth"
+        if any(
+            sub in err
+            for sub in (
+                "circuit breaker",
+                "unreachable",
+                "connection refused",
+                "timed out",
+                "timeout",
+                "mcp unavailable",
+            )
+        ):
+            return "unavailable"
+    return None
 
 
 async def format_response(state: AgentState) -> AgentState:
@@ -644,6 +700,75 @@ async def format_response(state: AgentState) -> AgentState:
         Updated state with ``final_response`` as formatted Markdown.
     """
     log.info("agent.format_response.start", request_id=state["request_id"])
+
+    pipeline_err = state.get("error")
+    if isinstance(pipeline_err, str) and pipeline_err.strip():
+        log.info(
+            "agent.format_response.pipeline_error_short_circuit",
+            request_id=state["request_id"],
+            error_head=pipeline_err[:160],
+        )
+        if (
+            "Tool selection failed" in pipeline_err
+            or "Intent classification failed" in pipeline_err
+        ):
+            state["final_response"] = (
+                "The assistant could not run the catalog tool-selection step, usually because "
+                "the OpenAI request failed or returned invalid JSON. Check **OPENAI_API_KEY**, "
+                "model access, and network connectivity, then try again."
+            )
+        else:
+            state["final_response"] = (
+                "Something went wrong while preparing this turn. Check server logs for this "
+                "request. If it keeps happening, verify **OPENAI_API_KEY** and OpenMetadata "
+                "settings (**AI_SDK_HOST**, **AI_SDK_TOKEN**)."
+            )
+        return state
+
+    records = state.get("tool_records") or []
+    error_codes = _mcp_error_codes_from_records(records)
+    if "om_auth_failed" in error_codes:
+        state["final_response"] = (
+            "OpenMetadata rejected the bot credentials (**AI_SDK_TOKEN** in the repository "
+            "root `.env`). Update the JWT, then **restart the FastAPI process** so the MCP "
+            "client cache reloads. The UI health check does not call OpenMetadata; the drift "
+            "sidebar uses the same token and will stay unavailable until auth succeeds."
+        )
+        log.info("agent.format_response.om_auth_short_circuit", request_id=state["request_id"])
+        return state
+    if "om_unavailable" in error_codes:
+        state["final_response"] = (
+            "OpenMetadata MCP is unreachable from the agent (timeout, connection error, or "
+            "circuit breaker open). Confirm **AI_SDK_HOST**, **OM_MCP_HTTP_PATH**, and that "
+            "OpenMetadata is running, then try again."
+        )
+        log.info(
+            "agent.format_response.om_unavailable_short_circuit", request_id=state["request_id"]
+        )
+        return state
+
+    results_early = state.get("tool_results") or []
+    inferred = _infer_om_issue_from_tool_results(results_early)
+    if inferred == "auth":
+        state["final_response"] = (
+            "OpenMetadata rejected the bot credentials (**AI_SDK_TOKEN** in the repository "
+            "root `.env`). Update the JWT, then **restart the FastAPI process** so the MCP "
+            "client cache reloads. The UI health check does not call OpenMetadata; drift "
+            "uses the same token."
+        )
+        log.info("agent.format_response.om_auth_from_tool_results", request_id=state["request_id"])
+        return state
+    if inferred == "unavailable":
+        state["final_response"] = (
+            "OpenMetadata MCP is unreachable from the agent (timeout, connection error, or "
+            "circuit breaker open). Confirm **AI_SDK_HOST**, **OM_MCP_HTTP_PATH**, and that "
+            "OpenMetadata is running, then try again."
+        )
+        log.info(
+            "agent.format_response.om_unavailable_from_tool_results",
+            request_id=state["request_id"],
+        )
+        return state
 
     # Build context for the formatter
     context_parts = [f"User question: {state['user_message']}"]

--- a/src/copilot/services/drift.py
+++ b/src/copilot/services/drift.py
@@ -31,7 +31,8 @@ from enum import StrEnum
 from typing import Any
 
 from copilot.clients import om_mcp
-from copilot.middleware.error_envelope import McpUnavailable
+from copilot.middleware.error_envelope import McpAuthFailed, McpUnavailable
+from copilot.models.mcp_tools import GetEntityDetailsParams
 from copilot.observability import get_logger
 
 log = get_logger(__name__)
@@ -64,6 +65,7 @@ class DriftSnapshot:
     scanned_at: str | None = None
     entity_count: int = 0
     error: str | None = None
+    auth_failed: bool = False
 
 
 # Module-level mutable state — drift results cached between polls.
@@ -217,6 +219,14 @@ async def run_drift_scan() -> DriftSnapshot:
             "search_metadata",
             {"query": "*", "limit": 100},
         )
+    except McpAuthFailed as exc:
+        log.warning("drift.scan.mcp_auth_failed", error=str(exc))
+        _latest_snapshot = DriftSnapshot(
+            scanned_at=now,
+            error="OpenMetadata authentication failed (check AI_SDK_TOKEN).",
+            auth_failed=True,
+        )
+        return _latest_snapshot
     except McpUnavailable as exc:
         log.warning("drift.scan.mcp_unavailable", error=str(exc))
         _latest_snapshot = DriftSnapshot(
@@ -225,8 +235,11 @@ async def run_drift_scan() -> DriftSnapshot:
         )
         return _latest_snapshot
 
-    # Normalise search results to a list of hits
-    hits = search_result.get("hits", search_result.get("data", []))
+    # Normalise search results to a list of hits (OM MCP may use hits, data, or results)
+    hits = search_result.get(
+        "hits",
+        search_result.get("data", search_result.get("results", [])),
+    )
     if isinstance(hits, dict):
         hits = hits.get("hits", [])
 
@@ -240,11 +253,19 @@ async def run_drift_scan() -> DriftSnapshot:
             continue
 
         try:
-            entity = await asyncio.to_thread(
-                om_mcp.call_tool,
-                "get_entity_details",
-                {"fqn": fqn, "entity_type": entity_type},
+            details = await asyncio.to_thread(
+                om_mcp.get_entity_details_typed,
+                GetEntityDetailsParams(entity_type=entity_type, fqn=fqn),
             )
+            entity = details.model_dump(by_alias=True, exclude_none=True)
+        except McpAuthFailed as exc:
+            log.warning("drift.scan.mcp_auth_failed_entity", fqn=fqn, error=str(exc))
+            _latest_snapshot = DriftSnapshot(
+                scanned_at=now,
+                error="OpenMetadata authentication failed (check AI_SDK_TOKEN).",
+                auth_failed=True,
+            )
+            return _latest_snapshot
         except McpUnavailable:
             log.warning("drift.scan.entity_fetch_failed", fqn=fqn)
             continue

--- a/tests/unit/test_agent.py
+++ b/tests/unit/test_agent.py
@@ -418,6 +418,72 @@ class TestFormatResponse:
     """Tests for the format_response node."""
 
     @patch("copilot.services.agent.openai_client.call_chat", new_callable=AsyncMock)
+    async def test_short_circuits_on_om_auth_failed_without_llm(
+        self, mock_llm: AsyncMock, base_state: AgentState
+    ) -> None:
+        """OM auth failures must not go to the formatter LLM (prompt forbids error detail)."""
+        base_state["tool_records"] = [
+            {
+                "tool_name": "search_metadata",
+                "success": False,
+                "error_code": "om_auth_failed",
+            },
+        ]
+        base_state["tool_results"] = [{"error": "OM auth failed for tool search_metadata"}]
+
+        result = await format_response(base_state)
+
+        mock_llm.assert_not_awaited()
+        assert result["final_response"] is not None
+        assert "AI_SDK_TOKEN" in result["final_response"]
+        assert "restart" in result["final_response"].lower()
+
+    @patch("copilot.services.agent.openai_client.call_chat", new_callable=AsyncMock)
+    async def test_short_circuits_on_om_unavailable_without_llm(
+        self, mock_llm: AsyncMock, base_state: AgentState
+    ) -> None:
+        base_state["tool_records"] = [
+            {
+                "tool_name": "search_metadata",
+                "success": False,
+                "error_code": "om_unavailable",
+            },
+        ]
+        base_state["tool_results"] = [{"error": "timeout"}]
+
+        result = await format_response(base_state)
+
+        mock_llm.assert_not_awaited()
+        assert result["final_response"] is not None
+        assert "OpenMetadata MCP" in result["final_response"]
+
+    @patch("copilot.services.agent.openai_client.call_chat", new_callable=AsyncMock)
+    async def test_short_circuits_on_om_auth_from_tool_results_only(
+        self, mock_llm: AsyncMock, base_state: AgentState
+    ) -> None:
+        """Infer OM auth failure from tool result payload when error_code is absent."""
+        base_state["tool_records"] = []
+        base_state["tool_results"] = [{"error": "OM auth failed for tool search_metadata"}]
+
+        result = await format_response(base_state)
+
+        mock_llm.assert_not_awaited()
+        assert "AI_SDK_TOKEN" in (result["final_response"] or "")
+
+    @patch("copilot.services.agent.openai_client.call_chat", new_callable=AsyncMock)
+    async def test_short_circuits_on_pipeline_error_without_llm(
+        self, mock_llm: AsyncMock, base_state: AgentState
+    ) -> None:
+        base_state["error"] = "Tool selection failed: timeout from OpenAI"
+        base_state["tool_results"] = []
+
+        result = await format_response(base_state)
+
+        mock_llm.assert_not_awaited()
+        assert result["final_response"] is not None
+        assert "OPENAI_API_KEY" in result["final_response"]
+
+    @patch("copilot.services.agent.openai_client.call_chat", new_callable=AsyncMock)
     async def test_formats_response_as_markdown(
         self, mock_llm: AsyncMock, base_state: AgentState
     ) -> None:

--- a/tests/unit/test_generate_bot_jwt.py
+++ b/tests/unit/test_generate_bot_jwt.py
@@ -207,6 +207,17 @@ class TestGenerateToken:
         )
         assert token == "token-from-alias"
 
+    @patch("generate_bot_jwt.urllib.request.urlopen")
+    def test_token_accepts_jwt_token_camel_case(self, mock_urlopen: MagicMock) -> None:
+        """Jackson may serialize JWTAuthMechanism.jwtToken as camelCase."""
+        mock_urlopen.return_value = _mock_response({"jwtToken": "token-from-camel"})
+
+        user_data = {"id": "user-uuid-123", "name": "ingestion-bot"}
+        token = generate_bot_jwt.generate_token(
+            "http://localhost:8585", "admin-token", user_data, "30"
+        )
+        assert token == "token-from-camel"
+
 
 class TestMain:
     @patch("generate_bot_jwt.generate_token")

--- a/tests/unit/test_governance_api.py
+++ b/tests/unit/test_governance_api.py
@@ -36,7 +36,7 @@ os.environ.setdefault("HOST", "127.0.0.1")
 os.environ.setdefault("PORT", "8000")
 os.environ.setdefault("LOG_LEVEL", "warning")
 
-from copilot.middleware.error_envelope import McpUnavailable
+from copilot.middleware.error_envelope import McpAuthFailed, McpUnavailable
 from copilot.services.drift import reset_state, run_drift_scan
 
 
@@ -106,6 +106,32 @@ class TestDriftEndpoint:
         assert body["drift_count"] == 0
         assert body["entity_count"] == 1
 
+    def test_drift_200_after_clean_scan_results_shape(self, client: TestClient) -> None:
+        """Drift scan accepts OM search payloads that use 'results' instead of 'hits'."""
+        mock_search = {
+            "results": [
+                {"fullyQualifiedName": "db.schema.table1", "entityType": "table"},
+            ],
+        }
+        mock_entity = {
+            "description": "A table",
+            "columns": [{"name": "id", "dataType": "INT", "tags": []}],
+            "tags": [{"tagFQN": "Tier.Tier1"}],
+        }
+
+        def mock_call_tool(name: str, args: dict[str, Any]) -> dict[str, Any]:
+            if name == "search_metadata":
+                return mock_search
+            return mock_entity
+
+        with patch("copilot.services.drift.om_mcp.call_tool", side_effect=mock_call_tool):
+            asyncio.run(run_drift_scan())
+
+        resp = client.get("/api/v1/governance/drift")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["entity_count"] == 1
+
     def test_drift_200_detects_hash_change(self, client: TestClient) -> None:
         """After baseline set, changing an entity should produce drift items."""
         mock_search = {
@@ -163,3 +189,36 @@ class TestDriftEndpoint:
         assert resp.status_code == 503
         body = resp.json()
         assert body["code"] == "om_unavailable"
+
+    def test_drift_502_when_om_auth_failed(self, client: TestClient) -> None:
+        """When OM rejects the bot token, GET drift returns om_auth_failed."""
+        with patch(
+            "copilot.services.drift.om_mcp.call_tool",
+            side_effect=McpAuthFailed("OM auth failed for tool search_metadata"),
+        ):
+            asyncio.run(run_drift_scan())
+
+        resp = client.get("/api/v1/governance/drift")
+        assert resp.status_code == 502
+        body = resp.json()
+        assert body["code"] == "om_auth_failed"
+
+    def test_drift_502_when_om_auth_failed_on_entity_fetch(self, client: TestClient) -> None:
+        """Auth failure during get_entity_details updates snapshot like search failures."""
+
+        def mock_call_tool(name: str, args: dict[str, Any]) -> dict[str, Any]:
+            if name == "search_metadata":
+                return {
+                    "results": [
+                        {"fullyQualifiedName": "db.schema.table1", "entityType": "table"},
+                    ],
+                }
+            raise McpAuthFailed("OM auth failed for tool get_entity_details")
+
+        with patch("copilot.services.drift.om_mcp.call_tool", side_effect=mock_call_tool):
+            asyncio.run(run_drift_scan())
+
+        resp = client.get("/api/v1/governance/drift")
+        assert resp.status_code == 502
+        body = resp.json()
+        assert body["code"] == "om_auth_failed"

--- a/tests/unit/test_om_mcp.py
+++ b/tests/unit/test_om_mcp.py
@@ -170,6 +170,26 @@ class TestCallTool:
             om_mcp.call_tool("search_metadata", {"query": "test"})
 
     @patch("copilot.clients.om_mcp._get_sdk_client")
+    def test_raises_mcp_auth_failed_when_mcp_error_chains_authentication_error(
+        self, mock_get_sdk: MagicMock
+    ) -> None:
+        """HTTP 401 becomes AuthenticationError; MCP wraps it without '401' in str."""
+        from ai_sdk.exceptions import AuthenticationError
+
+        from copilot.clients.om_mcp import MCPError
+
+        def _boom(*_a: Any, **_kw: Any) -> None:
+            try:
+                raise AuthenticationError()
+            except AuthenticationError as e:
+                raise MCPError(f"MCP request failed: {e}") from e
+
+        mock_get_sdk.return_value = _mock_sdk(side_effect=_boom)
+
+        with pytest.raises(McpAuthFailed):
+            om_mcp.call_tool("search_metadata", {"query": "test"})
+
+    @patch("copilot.clients.om_mcp._get_sdk_client")
     def test_raises_mcp_auth_failed_on_403(self, mock_get_sdk: MagicMock) -> None:
         """403 Forbidden also maps to McpAuthFailed."""
         from copilot.clients.om_mcp import MCPError
@@ -445,6 +465,23 @@ class TestSearchMetadataTypedFailures:
         assert result.total == 1
         assert len(result.hits) == 1
         assert result.hits[0].fully_qualified_name == "db.users"
+
+    @patch("copilot.clients.om_mcp.call_tool")
+    def test_normalises_results_key_to_hits(self, mock_call: Any) -> None:
+        """OM MCP may return search rows under 'results' instead of 'hits'."""
+        from copilot.clients.om_mcp import search_metadata_typed
+
+        mock_call.return_value = {
+            "results": [{"fullyQualifiedName": "db.widgets", "entityType": "table"}],
+            "totalFound": 1,
+        }
+        params = SearchMetadataParams(query="*")
+        result = search_metadata_typed(params)
+
+        assert isinstance(result, SearchMetadataResponse)
+        assert result.total == 1
+        assert len(result.hits) == 1
+        assert result.hits[0].fully_qualified_name == "db.widgets"
 
     @patch("copilot.clients.om_mcp.call_tool")
     def test_normalises_nested_hits_dict(self, mock_call: Any) -> None:

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -14,14 +14,27 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 from pydantic import SecretStr
 
+import copilot.config.settings as settings_module
 from copilot.config.settings import Settings, assert_runtime_env_ready
 
 # Non-JWT-shaped value: scanners (e.g. GitGuardian) flag eyJ... three-segment tokens in PRs.
 # Runtime checks only need a non-placeholder secret (see _is_placeholder_secret).
 _UNIT_TEST_OM_SDK_TOKEN_OK = "copilot-unit-test-om-bot-credential-not-a-jwt-0123456789ab"
+
+
+class TestEnvFileLocation:
+    """Regression: Settings must load ``.env`` from repo root, not process cwd (see SC / OM MCP 401)."""
+
+    def test_model_config_env_file_is_repository_dotenv(self) -> None:
+        env_file = Settings.model_config.get("env_file")
+        assert env_file is not None
+        expected = Path(settings_module.__file__).resolve().parent.parent.parent.parent / ".env"
+        assert Path(str(env_file)).resolve() == expected.resolve()
 
 
 class TestSC1LoopbackBindOnly:
@@ -50,6 +63,11 @@ class TestSC2SecretStrTyping:
     def test_secret_value_extractable_with_explicit_call(self) -> None:
         s = Settings(_env_file=None, ai_sdk_token="real-value-here")  # type: ignore[call-arg]
         assert s.ai_sdk_token.get_secret_value() == "real-value-here"
+
+    def test_ai_sdk_token_strips_bearer_prefix(self) -> None:
+        """Users sometimes paste ``Bearer eyJ...``; SDK already sends Bearer."""
+        s = Settings(_env_file=None, ai_sdk_token="Bearer  my-jwt-value")  # type: ignore[call-arg]
+        assert s.ai_sdk_token.get_secret_value() == "my-jwt-value"
 
 
 class TestResilienceKnobs:

--- a/ui/.env.example
+++ b/ui/.env.example
@@ -1,2 +1,9 @@
 # UI environment template. Copy to .env and adjust if backend port differs.
-VITE_API_URL=http://localhost:8000
+#
+# Match the API bind address: backend defaults to HOST=127.0.0.1 (see repo .env.example).
+# Using http://localhost:8000 while the API listens only on 127.0.0.1 can hit a different
+# process on some systems; prefer the same host the browser should reach.
+VITE_API_URL=http://127.0.0.1:8000
+#
+# After changing AI_SDK_TOKEN or OM URL in the repo-root .env, restart the FastAPI process
+# so the MCP client cache picks up the new credentials (healthz does not use OM).

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -7,9 +7,9 @@
  *  http://www.apache.org/licenses/LICENSE-2.0
  */
 
-import { useState, useCallback, useRef, useEffect } from 'react';
+import { useState, useCallback, useRef, useEffect } from "react";
 
-const API_URL = import.meta.env['VITE_API_URL'] ?? 'http://localhost:8000';
+const API_URL = import.meta.env["VITE_API_URL"] ?? "http://localhost:8000";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -25,7 +25,7 @@ interface AuditEntry {
 interface PendingConfirmation {
   proposal_id: string;
   tool_name: string;
-  risk_level: 'read' | 'soft_write' | 'hard_write';
+  risk_level: "read" | "soft_write" | "hard_write";
   rationale: string;
   arguments: Record<string, unknown>;
   expires_at: string | null;
@@ -56,7 +56,7 @@ interface ErrorEnvelope {
 }
 
 interface ChatMessage {
-  role: 'user' | 'assistant';
+  role: "user" | "assistant";
   content: string;
   pending?: PendingConfirmation;
 }
@@ -73,13 +73,17 @@ interface DriftSummaryPayload {
 
 function RiskBadge({ level }: { level: string }): JSX.Element {
   const cls =
-    level === 'hard_write'
-      ? 'risk-badge risk-badge--hard'
-      : level === 'soft_write'
-        ? 'risk-badge risk-badge--soft'
-        : 'risk-badge risk-badge--read';
+    level === "hard_write"
+      ? "risk-badge risk-badge--hard"
+      : level === "soft_write"
+      ? "risk-badge risk-badge--soft"
+      : "risk-badge risk-badge--read";
   const label =
-    level === 'hard_write' ? 'HIGH RISK' : level === 'soft_write' ? 'MEDIUM' : 'READ';
+    level === "hard_write"
+      ? "HIGH RISK"
+      : level === "soft_write"
+      ? "MEDIUM"
+      : "READ";
   return <span className={cls}>{label}</span>;
 }
 
@@ -102,8 +106,8 @@ function ConfirmationModal({
     setLoading(true);
     try {
       const res = await fetch(`${API_URL}/api/v1/chat/confirm`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           session_id: sessionId,
           proposal_id: pending.proposal_id,
@@ -113,9 +117,11 @@ function ConfirmationModal({
       const data = (await res.json()) as ChatResponse & Partial<ErrorEnvelope>;
       if (!res.ok) {
         onResolved({
-          request_id: data.request_id ?? '',
+          request_id: data.request_id ?? "",
           session_id: sessionId,
-          response: `${data.code ?? 'error'}: ${data.message ?? res.statusText}`,
+          response: `${data.code ?? "error"}: ${
+            data.message ?? res.statusText
+          }`,
           ts: new Date().toISOString(),
         });
         return;
@@ -123,9 +129,9 @@ function ConfirmationModal({
       onResolved(data as ChatResponse);
     } catch {
       onResolved({
-        request_id: '',
+        request_id: "",
         session_id: sessionId,
-        response: 'Failed to reach backend. Please try again.',
+        response: "Failed to reach backend. Please try again.",
         ts: new Date().toISOString(),
       });
     } finally {
@@ -134,7 +140,8 @@ function ConfirmationModal({
   }
 
   const argEntries = Object.entries(pending.arguments ?? {}).map(([k, v]) => {
-    const val = typeof v === 'string' && v.length > 80 ? v.slice(0, 80) + '…' : String(v);
+    const val =
+      typeof v === "string" && v.length > 80 ? v.slice(0, 80) + "…" : String(v);
     return { key: k, value: val };
   });
 
@@ -195,7 +202,7 @@ function ConfirmationModal({
             disabled={loading}
             onClick={() => void handleDecision(true)}
           >
-            {loading ? 'Applying…' : '✓ Confirm'}
+            {loading ? "Applying…" : "✓ Confirm"}
           </button>
           <button
             id="hitl-cancel-btn"
@@ -218,7 +225,7 @@ function ConfirmationModal({
 
 export function App(): JSX.Element {
   const [messages, setMessages] = useState<ChatMessage[]>([]);
-  const [input, setInput] = useState('');
+  const [input, setInput] = useState("");
   const [sending, setSending] = useState(false);
   const [sessionId, setSessionId] = useState<string | null>(null);
   const [pendingConfirmation, setPendingConfirmation] =
@@ -226,12 +233,14 @@ export function App(): JSX.Element {
   const [healthStatus, setHealthStatus] = useState<HealthStatus | null>(null);
   const [healthError, setHealthError] = useState<string | null>(null);
   const [chatError, setChatError] = useState<string | null>(null);
-  const [driftSummary, setDriftSummary] = useState<DriftSummaryPayload | null>(null);
+  const [driftSummary, setDriftSummary] = useState<DriftSummaryPayload | null>(
+    null
+  );
   const [driftError, setDriftError] = useState<string | null>(null);
   const messagesEndRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
   }, [messages]);
 
   const loadDriftSummary = useCallback(async () => {
@@ -254,12 +263,21 @@ export function App(): JSX.Element {
       setDriftSummary(data);
     } catch (e) {
       setDriftSummary(null);
-      setDriftError(e instanceof Error ? e.message : 'Unknown error');
+      setDriftError(e instanceof Error ? e.message : "Unknown error");
     }
   }, []);
 
   useEffect(() => {
     void loadDriftSummary();
+  }, [loadDriftSummary]);
+
+  // Re-fetch drift so the sidebar recovers after OM token fixes without a full page reload
+  // (background drift scan runs every 60s on the server).
+  useEffect(() => {
+    const id = window.setInterval(() => {
+      void loadDriftSummary();
+    }, 45_000);
+    return () => window.clearInterval(id);
   }, [loadDriftSummary]);
 
   async function checkHealth(): Promise<void> {
@@ -272,7 +290,7 @@ export function App(): JSX.Element {
       const data = (await response.json()) as HealthStatus;
       setHealthStatus(data);
     } catch (e) {
-      setHealthError(e instanceof Error ? e.message : 'Unknown error');
+      setHealthError(e instanceof Error ? e.message : "Unknown error");
       setHealthStatus(null);
     }
     void loadDriftSummary();
@@ -284,13 +302,13 @@ export function App(): JSX.Element {
 
     setSending(true);
     setChatError(null);
-    setMessages((prev) => [...prev, { role: 'user', content: text }]);
-    setInput('');
+    setMessages((prev) => [...prev, { role: "user", content: text }]);
+    setInput("");
 
     try {
       const res = await fetch(`${API_URL}/api/v1/chat`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           message: text,
           ...(sessionId ? { session_id: sessionId } : {}),
@@ -308,7 +326,10 @@ export function App(): JSX.Element {
         setChatError(errText);
         setMessages((prev) => [
           ...prev,
-          { role: 'assistant', content: `Could not complete request: ${errText}` },
+          {
+            role: "assistant",
+            content: `Could not complete request: ${errText}`,
+          },
         ]);
         return;
       }
@@ -317,9 +338,11 @@ export function App(): JSX.Element {
       setSessionId(data.session_id);
 
       const assistantMsg: ChatMessage = {
-        role: 'assistant',
-        content: data.response ?? '',
-        ...(data.pending_confirmation ? { pending: data.pending_confirmation } : {}),
+        role: "assistant",
+        content: data.response ?? "",
+        ...(data.pending_confirmation
+          ? { pending: data.pending_confirmation }
+          : {}),
       };
       setMessages((prev) => [...prev, assistantMsg]);
 
@@ -329,13 +352,13 @@ export function App(): JSX.Element {
         setPendingConfirmation(null);
       }
     } catch (e) {
-      const msg = e instanceof Error ? e.message : 'Unknown error';
+      const msg = e instanceof Error ? e.message : "Unknown error";
       setChatError(msg);
       setMessages((prev) => [
         ...prev,
         {
-          role: 'assistant',
-          content: 'Failed to reach backend. Is the server running?',
+          role: "assistant",
+          content: "Failed to reach backend. Is the server running?",
         },
       ]);
     } finally {
@@ -345,24 +368,27 @@ export function App(): JSX.Element {
 
   const handleConfirmationResolved = useCallback((response: ChatResponse) => {
     setPendingConfirmation(null);
-    setMessages((prev) => [...prev, { role: 'assistant', content: response.response ?? '' }]);
+    setMessages((prev) => [
+      ...prev,
+      { role: "assistant", content: response.response ?? "" },
+    ]);
   }, []);
 
   const driftCount = driftSummary?.drift_count ?? null;
   const driftStatusLabel =
     driftError !== null
-      ? 'Unavailable'
+      ? "Unavailable"
       : driftSummary === null
-        ? '…'
-        : driftCount === 0
-          ? 'No drift'
-          : 'Review needed';
+      ? "…"
+      : driftCount === 0
+      ? "No drift"
+      : "Review needed";
   const driftStatusClass =
     driftError !== null
-      ? 'app__card-value--error'
+      ? "app__card-value--error"
       : driftCount !== null && driftCount > 0
-        ? 'app__card-value--warning'
-        : 'app__card-value--good';
+      ? "app__card-value--warning"
+      : "app__card-value--good";
 
   return (
     <div className="app">
@@ -375,7 +401,9 @@ export function App(): JSX.Element {
         <aside className="app__sidebar">
           <div className="app__card">
             <h3 className="app__card-title">Drift status</h3>
-            <p className={`app__card-value ${driftStatusClass}`}>{driftStatusLabel}</p>
+            <p className={`app__card-value ${driftStatusClass}`}>
+              {driftStatusLabel}
+            </p>
             {driftError !== null && (
               <p className="app__sidebar-note">{driftError}</p>
             )}
@@ -386,8 +414,8 @@ export function App(): JSX.Element {
               {driftSummary !== null
                 ? String(driftSummary.drift_count)
                 : driftError !== null
-                  ? '—'
-                  : '…'}
+                ? "—"
+                : "…"}
             </p>
           </div>
           <div className="app__card">
@@ -396,8 +424,8 @@ export function App(): JSX.Element {
               {driftSummary !== null
                 ? String(driftSummary.entity_count)
                 : driftError !== null
-                  ? '—'
-                  : '…'}
+                ? "—"
+                : "…"}
             </p>
           </div>
           <div className="app__card">
@@ -406,8 +434,8 @@ export function App(): JSX.Element {
               {driftSummary?.scanned_at
                 ? new Date(driftSummary.scanned_at).toLocaleString()
                 : driftError !== null
-                  ? '—'
-                  : '…'}
+                ? "—"
+                : "…"}
             </p>
           </div>
 
@@ -418,12 +446,14 @@ export function App(): JSX.Element {
             {healthStatus !== null && (
               <pre className="app__status-output">
                 status: {healthStatus.status}
-                {'\n'}version: {healthStatus.version}
-                {'\n'}ts: {healthStatus.ts}
+                {"\n"}version: {healthStatus.version}
+                {"\n"}ts: {healthStatus.ts}
               </pre>
             )}
             {healthError !== null && (
-              <p className="app__status-error">Backend not reachable: {healthError}</p>
+              <p className="app__status-error">
+                Backend not reachable: {healthError}
+              </p>
             )}
           </section>
         </aside>
@@ -432,15 +462,23 @@ export function App(): JSX.Element {
           <section className="app__chat">
             <div className="chat__messages" id="chat-messages">
               {messages.length === 0 && (
-                <p className="chat__empty">Ask a question about your OpenMetadata catalog…</p>
+                <p className="chat__empty">
+                  Ask a question about your OpenMetadata catalog…
+                </p>
               )}
               {messages.map((msg, i) => (
-                <div key={i} className={`chat__bubble chat__bubble--${msg.role}`}>
-                  <span className="chat__role">{msg.role === 'user' ? 'You' : 'Agent'}</span>
+                <div
+                  key={i}
+                  className={`chat__bubble chat__bubble--${msg.role}`}
+                >
+                  <span className="chat__role">
+                    {msg.role === "user" ? "You" : "Agent"}
+                  </span>
                   <div className="chat__content">{msg.content}</div>
                   {msg.pending && (
                     <div className="chat__pending-hint">
-                      ⚠️ Write operation pending — see confirmation dialog above.
+                      ⚠️ Write operation pending — see confirmation dialog
+                      above.
                     </div>
                   )}
                 </div>
@@ -456,7 +494,7 @@ export function App(): JSX.Element {
                 value={input}
                 onChange={(e) => setInput(e.target.value)}
                 onKeyDown={(e) => {
-                  if (e.key === 'Enter' && !e.shiftKey) {
+                  if (e.key === "Enter" && !e.shiftKey) {
                     e.preventDefault();
                     void sendMessage();
                   }
@@ -470,10 +508,12 @@ export function App(): JSX.Element {
                 disabled={sending || !input.trim()}
                 onClick={() => void sendMessage()}
               >
-                {sending ? 'Sending…' : 'Send'}
+                {sending ? "Sending…" : "Send"}
               </button>
             </div>
-            {chatError !== null && <p className="app__chat-error">{chatError}</p>}
+            {chatError !== null && (
+              <p className="app__chat-error">{chatError}</p>
+            )}
             {sessionId !== null && (
               <p className="app__chat-session" data-testid="session-id">
                 session_id: {sessionId}
@@ -493,8 +533,10 @@ export function App(): JSX.Element {
 
       <footer className="app__footer">
         <p>
-          Phase 2 | Apache 2.0 |{' '}
-          <a href="https://github.com/GunaPalanivel/openmetadata-mcp-agent">repo</a>
+          Phase 2 | Apache 2.0 |{" "}
+          <a href="https://github.com/GunaPalanivel/openmetadata-mcp-agent">
+            repo
+          </a>
         </p>
       </footer>
     </div>


### PR DESCRIPTION
## Summary

- **Governance/drift:** Map OM `om_auth_failed` / 502; normalise `search_metadata` hits from `results`; use `get_entity_details_typed` in drift; entity-level auth errors handled.
- **MCP client:** `search_metadata_typed` accepts `results`; remove debug NDJSON.
- **Config:** Load repo-root `.env`; remove debug file logging in settings.
- **Chat:** `format_response` short-circuits on pipeline `state['error']`, `om_auth_failed` / `om_unavailable` in tool records, and inferred OM failures from `tool_results`; safer formatter prompt for greetings without tool results.
- **UI:** Drift refresh interval; `ui/.env.example` documents `VITE_API_URL` + API restart.
- **Scripts:** `diagnose_om_mcp_auth.py`, `generate_bot_jwt` token field support.

## Testing

- `pytest` unit tests for touched modules.

## Note

`om_auth_failed` in production still requires a valid `AI_SDK_TOKEN` and FastAPI restart after `.env` changes.
