### PR TITLE
chore: greeting/capability NL routing + OM connection hardening

### DIFF
--- a/src/copilot/clients/om_mcp.py
+++ b/src/copilot/clients/om_mcp.py
@@ -298,7 +298,7 @@ def _call_tool_inner(name: str, arguments: dict[str, Any]) -> dict[str, Any]:
         raise McpUnavailable(f"Tool {name} execution failed: {exc}") from exc
     except MCPError as exc:
         _cause = getattr(exc, "__cause__", None)
-        from ai_sdk.exceptions import AuthenticationError  # type: ignore[import-untyped]
+        from ai_sdk.exceptions import AuthenticationError
 
         if isinstance(_cause, AuthenticationError):
             raise McpAuthFailed(f"OM auth failed for tool {name}") from exc

--- a/src/copilot/clients/om_mcp.py
+++ b/src/copilot/clients/om_mcp.py
@@ -221,6 +221,11 @@ def call_tool(name: str, arguments: dict[str, Any]) -> dict[str, Any]:
 
     try:
         result = _call_tool_inner(name, arguments)
+    except pybreaker.CircuitBreakerError as exc:
+        elapsed_ms = int((time.monotonic() - start) * 1000)
+        log.warning("om.call_tool.failed", tool=name, elapsed_ms=elapsed_ms)
+        agent_mcp_calls_total.labels(tool_name=name, outcome="fail").inc()
+        raise McpUnavailable("OM MCP circuit breaker is open — too many recent failures") from exc
     except (McpUnavailable, McpAuthFailed):
         elapsed_ms = int((time.monotonic() - start) * 1000)
         log.warning("om.call_tool.failed", tool=name, elapsed_ms=elapsed_ms)
@@ -308,7 +313,25 @@ def _call_tool_inner(name: str, arguments: dict[str, Any]) -> dict[str, Any]:
         raise McpUnavailable(f"MCP error calling {name}: {exc}") from exc
     except pybreaker.CircuitBreakerError as exc:
         raise McpUnavailable("OM MCP circuit breaker is open — too many recent failures") from exc
+    except (ConnectionRefusedError, ConnectionAbortedError, ConnectionResetError) as exc:
+        raise McpUnavailable(f"OM unreachable: {exc}") from exc
+    except OSError as exc:
+        # Windows often surfaces "actively refused" as OSError(WinError 10061).
+        if (
+            getattr(exc, "winerror", None) == 10061
+            or "10061" in str(exc).lower()
+            or "refused" in str(exc).lower()
+        ):
+            raise McpUnavailable(f"OM unreachable: {exc}") from exc
+        raise McpUnavailable(f"Unexpected error calling {name}: {type(exc).__name__}") from exc
     except Exception as exc:
+        import httpx
+
+        if isinstance(
+            exc,
+            (httpx.ConnectError, httpx.ReadTimeout, httpx.WriteTimeout, httpx.PoolTimeout),
+        ):
+            raise McpUnavailable(f"OM unreachable: {exc}") from exc
         raise McpUnavailable(f"Unexpected error calling {name}: {type(exc).__name__}") from exc
 
     if not result.success:

--- a/src/copilot/services/agent.py
+++ b/src/copilot/services/agent.py
@@ -54,7 +54,7 @@ from copilot.models.chat import risk_level_for
 from copilot.models.governance_state import GovernanceState
 from copilot.observability import get_logger
 from copilot.services import governance_store
-from copilot.services.nl_router import route_query
+from copilot.services.nl_router import route_query, should_omit_mcp_tools
 from copilot.services.sessions import set_pending
 from copilot.services.tool_audit import redact_tool_arguments, summarize_tool_result
 
@@ -303,6 +303,15 @@ async def select_tools(state: AgentState) -> AgentState:
             request_id=state["request_id"],
             tool_count=len(proposals),
             tools=[p["name"] for p in proposals],
+        )
+        return state
+
+    if should_omit_mcp_tools(state["user_message"]):
+        state["tool_proposals"] = []
+        log.info(
+            "agent.select_tools.skip_om",
+            request_id=state["request_id"],
+            reason="greeting_or_capability",
         )
         return state
 

--- a/src/copilot/services/agent.py
+++ b/src/copilot/services/agent.py
@@ -214,6 +214,12 @@ Available tools (ONLY use these):
 
 Given the user's message and classified intent, select the tools to call and their arguments.
 
+Rules:
+- If the user asks for lineage, entity details, or column/schema information but does not name a
+  specific table, topic, or fully qualified name (FQN), return an empty "tools" list. Do not call
+  get_entity_lineage or get_entity_details with empty or placeholder arguments. Put a short note in
+  "rationale" that the user should name the entity (e.g. service.database.table).
+
 Respond with ONLY a JSON object:
 {
   "tools": [
@@ -295,6 +301,17 @@ async def select_tools(state: AgentState) -> AgentState:
     """
     log.info("agent.select_tools.start", request_id=state["request_id"], intent=state["intent"])
 
+    # Must run before the classify auto-chain: mis-classified greetings would otherwise
+    # inject search_metadata / get_entity_details and hit OM on every "hi".
+    if should_omit_mcp_tools(state["user_message"]):
+        state["tool_proposals"] = []
+        log.info(
+            "agent.select_tools.skip_om",
+            request_id=state["request_id"],
+            reason="greeting_or_capability",
+        )
+        return state
+
     if state.get("intent") == "classify":
         proposals = _auto_classification_proposals()
         state["tool_proposals"] = proposals
@@ -303,15 +320,6 @@ async def select_tools(state: AgentState) -> AgentState:
             request_id=state["request_id"],
             tool_count=len(proposals),
             tools=[p["name"] for p in proposals],
-        )
-        return state
-
-    if should_omit_mcp_tools(state["user_message"]):
-        state["tool_proposals"] = []
-        log.info(
-            "agent.select_tools.skip_om",
-            request_id=state["request_id"],
-            reason="greeting_or_capability",
         )
         return state
 
@@ -608,13 +616,46 @@ async def execute_tool(state: AgentState) -> AgentState:
             record.completed_at = end
             record.duration_ms = int((end - start).total_seconds() * 1000)
             record.success = False
-            record.error_code = "internal_error"
-            log.exception(
-                "agent.execute_tool.failed",
-                tool=str(proposal.tool_name),
-                error=str(exc),
+            err_str = str(exc).lower()
+            om_unavailable_substrings = (
+                "circuit breaker",
+                "unreachable",
+                "connection refused",
+                "actively refused",
+                "10061",
+                "timeout",
+                "mcp unavailable",
             )
-            results.append({"error": "Internal error executing tool"})
+            om_auth_substrings = (
+                "auth",
+                "401",
+                "403",
+                "unauthorized",
+            )
+            if any(s in err_str for s in om_unavailable_substrings):
+                record.error_code = "om_unavailable"
+                log.warning(
+                    "agent.execute_tool.failed",
+                    tool=str(proposal.tool_name),
+                    error=str(exc),
+                )
+                results.append({"error": str(exc)})
+            elif any(s in err_str for s in om_auth_substrings):
+                record.error_code = "om_auth_failed"
+                log.warning(
+                    "agent.execute_tool.failed",
+                    tool=str(proposal.tool_name),
+                    error=str(exc),
+                )
+                results.append({"error": str(exc)})
+            else:
+                record.error_code = "internal_error"
+                log.exception(
+                    "agent.execute_tool.failed",
+                    tool=str(proposal.tool_name),
+                    error=str(exc),
+                )
+                results.append({"error": "Internal error executing tool"})
 
         records.append(record.model_dump(mode="json"))
 

--- a/src/copilot/services/nl_router.py
+++ b/src/copilot/services/nl_router.py
@@ -93,21 +93,48 @@ _ENTITY_NAME_PATTERN = re.compile(
     re.I,
 )
 
+# "What are the columns of the orders table" / "columns in the revenue table"
+_COLUMNS_OF_TABLE = re.compile(
+    r"\bcolumns?\s+(?:of|in|for)\s+the\s+([a-zA-Z_][\w.-]*)(?:\s+table)?\b",
+    re.I,
+)
+
+# Lineage / impact phrasings: "lineage of the orders table", "impact of raw_events", "from the customers table"
+_LINEAGE_ENTITY_PATTERNS: list[re.Pattern[str]] = [
+    re.compile(
+        r"\b(?:of|from)\s+the\s+([a-zA-Z_][\w.-]*)(?:\s+table)\b",
+        re.I,
+    ),
+    re.compile(
+        r"\b(?:of|for)\s+the\s+([a-zA-Z_][\w.-]*)(?:\s+table)\b",
+        re.I,
+    ),
+    re.compile(
+        r"\b(?:lineage|impact|dependenc(?:y|ies)|dependencies)\s+of\s+"
+        r"([a-zA-Z_][\w_.-]+)\b",
+        re.I,
+    ),
+]
+
 # Greetings / very short non-catalog messages — do not call MCP; formatter + prompt handle these.
 _GREETING_PATTERN = re.compile(
-    r"^(?:hi+|hey+|hello+|howdy|yo+|sup|what(?:'s| is) up|hm+|\?+)[\s!?.]*$",
+    r"^(?:hi+|hey+|hello+|howdy|yo+|sup|greetings?|what(?:'s| is) up|hm+|\?+)[\s!?.]*$",
     re.I,
 )
 
 # Meta questions about the assistant (capabilities) — no OM tool; answered in the UI/LLM formatter.
 _CAPABILITY_PATTERN = re.compile(
-    r"\b(?:"
-    r"what\s+(?:can\s+you|do\s+you|are\s+you\s+able)\b|"
-    r"how\s+(?:can\s+you|do\s+you)\b|"
-    r"what\s+(?:you\s+(?:can|do)\b|(?:can|does)\s+this)\b|"
-    r"what\s+you\s+can\s+give|"
-    r"what\s+can\s+this\s+give"
-    r")\b",
+    r"(?:"
+    r"\bwhat\s+(?:can\s+you|do\s+you|are\s+you\s+able)\b|"
+    r"\bhow\s+(?:can\s+you|do\s+you)\b|"
+    r"\bwhat\s+(?:you\s+(?:can|do)|(?:can|does)\s+this)(?:\s+give)?\b|"
+    r"\bwhat\s+you\s+can\s+give\b|"
+    r"\bwhat\s+can\s+this(?:\s+give)?\b|"
+    r"\bwhat\s+does\s+this\s+do\b|"
+    r"\bwhat\s+can\s+this\s+do\b|"
+    r"\bhelp\s*me\b|"
+    r"\bwhat(?:'s| is)\s+(?:this|available)\b"
+    r")",
     re.I,
 )
 
@@ -129,10 +156,20 @@ def _extract_entity_ref(message: str) -> str | None:
     if m:
         return m.group(1)
 
+    # Column lists: "columns of the orders table"
+    m = _COLUMNS_OF_TABLE.search(message)
+    if m:
+        return m.group(1)
+
     # Fall back to a simple name reference
     m = _ENTITY_NAME_PATTERN.search(message)
     if m:
         return m.group(1)
+
+    for pat in _LINEAGE_ENTITY_PATTERNS:
+        m2 = pat.search(message)
+        if m2:
+            return m2.group(1)
 
     return None
 
@@ -170,13 +207,11 @@ def route_query(message: str, intent: str | None = None) -> ToolRoute | None:
     # 1. Lineage queries — check first because they're unambiguous
     if intent == "lineage" or _any_match(_LINEAGE_PATTERNS, text):
         entity = _extract_entity_ref(text)
-        args: dict[str, Any] = {}
-        if entity:
-            args["fqn"] = entity
-            args["entity_type"] = "table"
+        if not entity:
+            return None
         return ToolRoute(
             tool_name="get_entity_lineage",
-            arguments=args,
+            arguments={"fqn": entity, "entity_type": "table"},
             rationale="Query matches lineage pattern (upstream/downstream/depends)",
         )
 
@@ -191,13 +226,11 @@ def route_query(message: str, intent: str | None = None) -> ToolRoute | None:
     # 3. Entity details — "tell me about X", "what is X?"
     if _any_match(_DETAILS_PATTERNS, text):
         entity = _extract_entity_ref(text)
-        args = {}
-        if entity:
-            args["fqn"] = entity
-            args["entity_type"] = "table"
+        if not entity:
+            return None
         return ToolRoute(
             tool_name="get_entity_details",
-            arguments=args,
+            arguments={"fqn": entity, "entity_type": "table"},
             rationale="Query matches entity-details pattern (tell me about / what is)",
         )
 

--- a/src/copilot/services/nl_router.py
+++ b/src/copilot/services/nl_router.py
@@ -93,6 +93,34 @@ _ENTITY_NAME_PATTERN = re.compile(
     re.I,
 )
 
+# Greetings / very short non-catalog messages — do not call MCP; formatter + prompt handle these.
+_GREETING_PATTERN = re.compile(
+    r"^(?:hi+|hey+|hello+|howdy|yo+|sup|what(?:'s| is) up|hm+|\?+)[\s!?.]*$",
+    re.I,
+)
+
+# Meta questions about the assistant (capabilities) — no OM tool; answered in the UI/LLM formatter.
+_CAPABILITY_PATTERN = re.compile(
+    r"\b(?:"
+    r"what\s+(?:can\s+you|do\s+you|are\s+you\s+able)\b|"
+    r"how\s+(?:can\s+you|do\s+you)\b|"
+    r"what\s+(?:you\s+(?:can|do)\b|(?:can|does)\s+this)\b|"
+    r"what\s+you\s+can\s+give|"
+    r"what\s+can\s+this\s+give"
+    r")\b",
+    re.I,
+)
+
+
+def should_omit_mcp_tools(message: str) -> bool:
+    """True when we should not invoke OpenMetadata MCP (greeting, capability question, etc.)."""
+    text = message.strip()
+    if not text:
+        return True
+    if _GREETING_PATTERN.match(text):
+        return True
+    return _CAPABILITY_PATTERN.search(text) is not None
+
 
 def _extract_entity_ref(message: str) -> str | None:
     """Try to extract a FQN or entity name from the message."""
@@ -132,6 +160,11 @@ def route_query(message: str, intent: str | None = None) -> ToolRoute | None:
     """
     text = message.strip()
     if not text:
+        return None
+
+    if _GREETING_PATTERN.match(text):
+        return None
+    if _CAPABILITY_PATTERN.search(text):
         return None
 
     # 1. Lineage queries — check first because they're unambiguous

--- a/tests/unit/test_agent.py
+++ b/tests/unit/test_agent.py
@@ -105,6 +105,14 @@ class TestClassifyIntent:
 class TestSelectTools:
     """Tests for the select_tools node."""
 
+    async def test_greeting_skips_om_and_llm(self, base_state: AgentState) -> None:
+        """Greetings do not call MCP or the tool-selection LLM."""
+        from copilot.services.agent import select_tools
+
+        base_state["user_message"] = "hi"
+        result = await select_tools(base_state)
+        assert result["tool_proposals"] == []
+
     async def test_deterministic_route_skips_llm(self, base_state: AgentState) -> None:
         """Common search queries are routed deterministically without an LLM call."""
         from copilot.services.agent import select_tools

--- a/tests/unit/test_agent.py
+++ b/tests/unit/test_agent.py
@@ -113,6 +113,17 @@ class TestSelectTools:
         result = await select_tools(base_state)
         assert result["tool_proposals"] == []
 
+    async def test_greeting_skips_classify_auto_chain_when_intent_misclassified(
+        self, base_state: AgentState
+    ) -> None:
+        """If the LLM labels a greeting as classify, we must not inject the OM demo tool chain."""
+        from copilot.services.agent import select_tools
+
+        base_state["intent"] = "classify"
+        base_state["user_message"] = "hi"
+        result = await select_tools(base_state)
+        assert result["tool_proposals"] == []
+
     async def test_deterministic_route_skips_llm(self, base_state: AgentState) -> None:
         """Common search queries are routed deterministically without an LLM call."""
         from copilot.services.agent import select_tools
@@ -419,6 +430,44 @@ class TestExecuteTool:
 
         assert len(result["tool_records"]) == 1
         assert result["tool_records"][0]["success"] is False
+        assert result["tool_records"][0]["error_code"] == "om_auth_failed"
+
+    @patch("copilot.services.agent.asyncio.to_thread", new_callable=AsyncMock)
+    async def test_classifies_bare_exception_with_om_keywords_as_unavailable(
+        self, mock_to_thread: AsyncMock, base_state: AgentState
+    ) -> None:
+        """Stray tool errors (e.g. circuit breaker) get om_unavailable for formatter short-circuit."""
+        mock_to_thread.side_effect = RuntimeError("OM MCP circuit breaker is open after failures")
+
+        proposal = ToolCallProposal(
+            request_id=uuid4(),
+            tool_name=ToolName.SEARCH_METADATA,
+            arguments={"query": "test"},
+            risk_level=RiskLevel.READ,
+        )
+        base_state["tool_proposals"] = [proposal]
+
+        result = await execute_tool(base_state)
+
+        assert result["tool_records"][0]["error_code"] == "om_unavailable"
+        assert "circuit breaker" in str(result["tool_results"][0]["error"]).lower()
+
+    @patch("copilot.services.agent.asyncio.to_thread", new_callable=AsyncMock)
+    async def test_bare_auth_like_exception_gets_om_auth_failed(
+        self, mock_to_thread: AsyncMock, base_state: AgentState
+    ) -> None:
+        mock_to_thread.side_effect = Exception("unauthorized: 401 from gateway")
+
+        proposal = ToolCallProposal(
+            request_id=uuid4(),
+            tool_name=ToolName.SEARCH_METADATA,
+            arguments={"query": "test"},
+            risk_level=RiskLevel.READ,
+        )
+        base_state["tool_proposals"] = [proposal]
+
+        result = await execute_tool(base_state)
+
         assert result["tool_records"][0]["error_code"] == "om_auth_failed"
 
 

--- a/tests/unit/test_nl_router.py
+++ b/tests/unit/test_nl_router.py
@@ -132,7 +132,6 @@ class TestLineageRouting:
             "What are the upstream dependencies of dim_orders?",
             "Show downstream impact of raw_events",
             "Trace back data for the revenue table",
-            "What feeds into the analytics pipeline?",
             "What flows from the customers table?",
         ],
     )
@@ -146,11 +145,14 @@ class TestLineageRouting:
         assert result is not None
         assert result.arguments.get("fqn") == "customer_db.public.users"
 
-    def test_lineage_intent_override(self) -> None:
-        """Even without keyword match, intent=lineage forces lineage routing."""
-        result = route_query("Show me the graph for orders", intent="lineage")
-        assert result is not None
-        assert result.tool_name == "get_entity_lineage"
+    def test_lineage_intent_no_extracted_entity_returns_none(self) -> None:
+        """Lineage intent without a resolvable FQN/entity defers to LLM (or clarification)."""
+        assert route_query("Show me the graph for orders", intent="lineage") is None
+
+    def test_lineage_without_entity_returns_none(self) -> None:
+        """Generic upstream/downstream wording with no table name must not call OM with empty args."""
+        assert route_query("Check the upstream and downstream impact") is None
+        assert route_query("What feeds into the analytics pipeline?") is None
 
 
 # ---------------------------------------------------------------------------
@@ -231,6 +233,11 @@ class TestEdgeCases:
         assert route_query("What can you do?") is None
         assert route_query("what you can give") is None
         assert should_omit_mcp_tools("What can you do for me?")
+        assert should_omit_mcp_tools("help me")
+        assert should_omit_mcp_tools("Greetings!")
+
+    def test_details_pattern_without_entity_returns_none(self) -> None:
+        assert route_query("Tell me about") is None
 
     def test_returns_tool_route_dataclass(self) -> None:
         result = route_query("Show me tables", intent="search")

--- a/tests/unit/test_nl_router.py
+++ b/tests/unit/test_nl_router.py
@@ -37,7 +37,7 @@ os.environ.setdefault("LOG_LEVEL", "warning")
 
 import pytest
 
-from copilot.services.nl_router import ToolRoute, route_query
+from copilot.services.nl_router import ToolRoute, route_query, should_omit_mcp_tools
 
 # ---------------------------------------------------------------------------
 # Search → search_metadata
@@ -220,6 +220,17 @@ class TestEdgeCases:
     def test_empty_input_returns_none(self) -> None:
         assert route_query("") is None
         assert route_query("  ") is None
+
+    def test_greeting_does_not_route_to_search(self) -> None:
+        assert route_query("hi") is None
+        assert route_query("?") is None
+        assert route_query("hello!") is None
+        assert should_omit_mcp_tools("hi")
+
+    def test_capability_questions_do_not_route_to_tools(self) -> None:
+        assert route_query("What can you do?") is None
+        assert route_query("what you can give") is None
+        assert should_omit_mcp_tools("What can you do for me?")
 
     def test_returns_tool_route_dataclass(self) -> None:
         result = route_query("Show me tables", intent="search")

--- a/tests/unit/test_om_mcp.py
+++ b/tests/unit/test_om_mcp.py
@@ -255,6 +255,16 @@ class TestCallTool:
         with pytest.raises(pybreaker.CircuitBreakerError):
             om_mcp._call_tool_inner("search_metadata", {"query": "test"})
 
+    @patch("copilot.clients.om_mcp._call_tool_inner")
+    def test_call_tool_maps_breaker_error_to_mcp_unavailable(self, mock_inner: MagicMock) -> None:
+        """Decorator-level breaker errors should not leak as internal_error upstream."""
+        mock_inner.side_effect = pybreaker.CircuitBreakerError(
+            "Timeout not elapsed yet, circuit breaker still open",
+        )
+
+        with pytest.raises(McpUnavailable, match="circuit breaker is open"):
+            om_mcp.call_tool("search_metadata", {"query": "test"})
+
 
 # =============================================================================
 # _call_tool_inner non-enum tool fallback tests


### PR DESCRIPTION
## Summary

- **nl_router:** Greeting and capability/meta questions return no deterministic tool; new `should_omit_mcp_tools()` is used by **select_tools** so the LLM tool path is skipped and **no MCP call** runs for short greetings or "what can you do" style messages.
- **om_mcp:** Map connection refused, common Windows refused `OSError`, and **httpx** connect/timeout errors to `McpUnavailable` (circuit-breaker errors remain mapped in `call_tool`).

## Tests

- `test_nl_router`, `TestSelectTools`, `TestCallTool`
